### PR TITLE
perf/10c: /api/tag 500 when care is missing (normalize parsed.care)

### DIFF
--- a/backend/test/e2e/tag.e2e.test.js
+++ b/backend/test/e2e/tag.e2e.test.js
@@ -106,6 +106,25 @@ test("POST /api/tag contract test validates required response fields", async (t)
   assertTagResponseContract(res.body);
 });
 
+test("POST /api/tag normalizes malformed care and still returns 200", async (t) => {
+  __setTagExtractorForTest(async () => ({
+    country: "Portugal",
+    materials: [{ fiber: "Cotton", pct: 100 }],
+    care: "machine_wash_cold",
+  }));
+  t.after(() => __resetTagExtractorForTest());
+
+  const res = await request(app).post("/api/tag").attach("image", fixtureImage);
+
+  assert.equal(res.status, 200);
+  assert.ok(res.body.parsed && typeof res.body.parsed === "object");
+  assert.ok(res.body.parsed.care && typeof res.body.parsed.care === "object");
+  assert.equal(res.body.parsed.care.washing, null);
+  assert.equal(res.body.parsed.care.drying, null);
+  assert.equal(res.body.parsed.care.ironing, null);
+  assert.equal(res.body.parsed.care.dry_cleaning, null);
+});
+
 const liveEnabled = process.env.E2E_LIVE === "1" && !!process.env.OPENAI_API_KEY;
 
 if (liveEnabled) {


### PR DESCRIPTION
# PR: Task 10C — Prevent `/api/tag` 500 by normalizing care before emissions

## Summary
This PR fixes a backend crash where `POST /api/tag` could return `500 INTERNAL_ERROR` when the AI output omitted or returned a malformed `parsed.care` field. The route now normalizes `parsed.care` into the structured shape required by the emissions estimator, preventing an internal server error and preserving the existing API contract. A regression E2E test is included.

## Motivation / Context
During mobile integration testing, uploads to `POST /api/tag` occasionally produced:

- `500 INTERNAL_ERROR`
- Backend error (from `estimateEmissions`):  
  `Care instructions must be a structured object with washing, drying, ironing, or dry_cleaning keys.`

This prevented the mobile app from reaching the success state even when extraction succeeded.

## Changes

### Backend fix
- `backend/api/tag.js`
  - Adds a small normalization step before `estimateEmissions(parsed)`:
    - Ensures `parsed` is an object
    - Ensures `parsed.care` is a plain object
    - Ensures keys exist: `washing`, `drying`, `ironing`, `dry_cleaning` (defaults to `null`)

### Regression test
- `backend/test/e2e/tag.e2e.test.js`
  - Adds E2E coverage: malformed or missing `care` is normalized and the endpoint still returns `200` (no 500).

## How to test

### Automated
```bash
cd backend
npm test
```

Expected: all mocked E2E tests pass; live OpenAI test remains skipped unless enabled.

### Manual sanity check
With backend running:
```bash
cd backend
node server.js
```

In another terminal:
```bash
curl -i -F "image=@../cropped_tags/IMG_8539.JPG" http://localhost:3001/api/tag
```

Expected: `200 OK` (no `500 INTERNAL_ERROR` due to care shape).

## Notes
- API contract remains unchanged: success returns `{ parsed, emissions }`; error responses remain stable `{ error: { code, message } }`.
- This unblocks the mobile integration flow by preventing emissions estimation from crashing on partial AI outputs.
