### PR TITLE
Created and benchmarked an exact match cache, semantic cache using CLIP , and tiered cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,14 @@ node_modules/
 *.log
 .env
 **/benchmarks/results/
+
+backend/cache/_tmp_semantic_sim.sqlite
+backend/cache/bench-exact.sqlite
+backend/cache/bench-sem-clip.sqlite
+backend/cache/bench-tiered-clip.sqlite
+backend/cache/ecotag-cache.sqlite
+backend/cache/exact.sqlite
+backend/cache/semantic.sqlite
+backend/cache/test-cache-service.sqlite
+backend/cache/test-tag-e2e.sqlite
+backend/uploads/

--- a/backend/ai/mock.js
+++ b/backend/ai/mock.js
@@ -1,0 +1,128 @@
+import { computeFingerprint, computeImageHash } from "../cache/fingerprint.js";
+
+const COUNTRIES = [
+  "Portugal",
+  "Vietnam",
+  "China",
+  "Bangladesh",
+  "India",
+  "Turkey",
+  "Mexico",
+  "Italy",
+  "Indonesia",
+  "Morocco",
+];
+
+const FIBERS = [
+  "Cotton",
+  "Polyester",
+  "Wool",
+  "Nylon",
+  "Viscose",
+  "Linen",
+  "Acrylic",
+  "Elastane",
+  "Rayon",
+];
+
+const WASHING = [
+  "machine_wash_cold",
+  "machine_wash_warm",
+  "machine_wash_hot",
+  "machine_wash_gentle",
+  "hand_wash_cold",
+  "hand_wash_warm",
+  null,
+];
+
+const DRYING = [
+  "tumble_dry_low",
+  "tumble_dry_medium",
+  "tumble_dry_high",
+  "lay_flat_to_dry",
+  "line_dry",
+  "do_not_tumble_dry",
+  null,
+];
+
+const IRONING = ["iron_low", "iron_medium", "iron_high", "do_not_iron", null];
+
+const DRY_CLEANING = ["dry_clean", "dry_clean_only", null];
+
+function sliceHexInt(hash, start) {
+  const safeStart = start % Math.max(hash.length - 8, 1);
+  const value = Number.parseInt(hash.slice(safeStart, safeStart + 8), 16);
+  if (!Number.isFinite(value)) return 0;
+  return value >>> 0;
+}
+
+function buildSeed(hash, fingerprint) {
+  const fingerprintSeed = Array.isArray(fingerprint)
+    ? Math.floor(
+        fingerprint.reduce(
+          (sum, value, idx) => sum + Math.abs(value) * (idx + 3) * 1000,
+          0,
+        ),
+      ) >>> 0
+    : 0;
+  return (sliceHexInt(hash, 0) ^ fingerprintSeed) >>> 0;
+}
+
+function pick(options, hash, seed, slot) {
+  const mixed =
+    (sliceHexInt(hash, slot * 7) ^ seed ^ Math.imul(slot + 11, 2654435761)) >>> 0;
+  return options[mixed % options.length];
+}
+
+function buildMaterials(hash, seed) {
+  const materialCount = (pick([1, 2, 3], hash, seed, 20) ?? 2) || 2;
+  const selected = [];
+  const used = new Set();
+
+  for (let i = 0; i < materialCount; i += 1) {
+    let idx = ((sliceHexInt(hash, 24 + i * 8) ^ seed) >>> 0) % FIBERS.length;
+    while (used.has(idx)) {
+      idx = (idx + 1) % FIBERS.length;
+    }
+    used.add(idx);
+    selected.push({
+      fiber: FIBERS[idx],
+      weight: ((sliceHexInt(hash, 80 + i * 8) % 1000) + 1) / 1000,
+    });
+  }
+
+  const totalWeight = selected.reduce((sum, item) => sum + item.weight, 0);
+  let running = 0;
+
+  return selected.map((item, idx) => {
+    if (idx === selected.length - 1) {
+      return { fiber: item.fiber, pct: Math.max(1, 100 - running) };
+    }
+    const remainingSlots = selected.length - idx - 1;
+    const maxAllowed = Math.max(1, 100 - running - remainingSlots);
+    const rawPct = Math.max(1, Math.round((item.weight / totalWeight) * 100));
+    const pct = Math.min(rawPct, maxAllowed);
+    running += pct;
+    return { fiber: item.fiber, pct };
+  });
+}
+
+export function extractMockTagFromArtifacts({ imageHash, fingerprint }) {
+  const seed = buildSeed(imageHash, fingerprint);
+  return {
+    country: pick(COUNTRIES, imageHash, seed, 1),
+    materials: buildMaterials(imageHash, seed),
+    care: {
+      washing: pick(WASHING, imageHash, seed, 2),
+      drying: pick(DRYING, imageHash, seed, 3),
+      ironing: pick(IRONING, imageHash, seed, 4),
+      dry_cleaning: pick(DRY_CLEANING, imageHash, seed, 5),
+    },
+  };
+}
+
+export function extractMockTagFromImageBuffer(imageBuffer, precomputed = null) {
+  const imageHash = precomputed?.imageHash ?? computeImageHash(imageBuffer);
+  const fingerprint = precomputed?.fingerprint ?? computeFingerprint(imageBuffer);
+  return extractMockTagFromArtifacts({ imageHash, fingerprint });
+}

--- a/backend/api/tag.js
+++ b/backend/api/tag.js
@@ -4,9 +4,13 @@
 import express from "express";
 import multer from "multer";
 import * as gpt from "../ai/gpt.js";
+import { extractMockTagFromImageBuffer } from "../ai/mock.js";
 import { estimateEmissions } from "../ai/emissions.js";
 import fs from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { getCacheConfig, isMockOcrEnabled } from "../cache/config.js";
+import { countCacheEntries, lookup, resetCacheEntries, store } from "../cache/service.js";
 
 const router = express.Router();
 const upload = multer({ dest: "uploads/" });
@@ -43,6 +47,31 @@ function withFallbackCareForEmissions(parsed) {
   };
 }
 
+function formatMs(value) {
+  if (!Number.isFinite(value)) return "0.00";
+  return Number(value).toFixed(2);
+}
+
+function formatSimilarity(value) {
+  if (!Number.isFinite(value)) return "";
+  return Number(value).toFixed(4);
+}
+
+function getRssMb() {
+  return (process.memoryUsage().rss / (1024 * 1024)).toFixed(2);
+}
+
+function applyCacheHeaders(res, metrics) {
+  res.set("X-Cache-Mode", metrics.mode || "tiered");
+  res.set("X-Cache-Embedder", metrics.embedder || "none");
+  res.set("X-Cache-Status", metrics.status || "MISS");
+  res.set("X-Cache-Similarity", metrics.similarity ?? "");
+  res.set("X-Cache-Embedding-Ms", metrics.embeddingMs ?? "0.00");
+  res.set("X-Cache-Lookup-Ms", metrics.lookupMs ?? "0.00");
+  res.set("X-Cache-False-Positive", metrics.falsePositive ?? "NA");
+  res.set("X-Cache-RSS-MB", getRssMb());
+}
+
 export function __setTagExtractorForTest(extractor) {
   tagExtractor = extractor;
 }
@@ -51,11 +80,53 @@ export function __resetTagExtractorForTest() {
   tagExtractor = gpt.extractTagFromImage;
 }
 
+// POST /api/cache/reset - Clears local cache entries (used by benchmark harness).
+router.post("/cache/reset", (_req, res) => {
+  try {
+    const { cacheEnabled } = getCacheConfig();
+    if (!cacheEnabled) {
+      return res.json({
+        ok: true,
+        cache_enabled: false,
+        cleared_entries: 0,
+      });
+    }
+
+    const before = countCacheEntries();
+    resetCacheEntries();
+    return res.json({
+      ok: true,
+      cache_enabled: true,
+      cleared_entries: before,
+    });
+  } catch (err) {
+    console.error("[EcoTag] /api/cache/reset failed.", err);
+    return res.status(500).json({
+      error: {
+        code: "CACHE_RESET_ERROR",
+        message: "Failed to reset cache.",
+      },
+    });
+  }
+});
+
 // POST /api/tag - Accepts image upload, returns tag info, CO2 estimate, and economic metrics.
 // Form fields: image (file), price (number, required), category (string, optional)
 router.post("/tag", upload.single("image"), async (req, res) => {
+  const { cacheMode, semanticEmbedder } = getCacheConfig();
+  const cacheMetrics = {
+    mode: cacheMode,
+    embedder: cacheMode === "exact" ? "none" : semanticEmbedder,
+    status: "MISS",
+    similarity: "",
+    embeddingMs: "0.00",
+    lookupMs: "0.00",
+    falsePositive: "NA",
+  };
+
   const filePath = req.file?.path;
   if (!filePath) {
+    applyCacheHeaders(res, cacheMetrics);
     return res.status(400).json({
       error: {
         code: "MISSING_IMAGE",
@@ -70,41 +141,96 @@ router.post("/tag", upload.single("image"), async (req, res) => {
       ext === "jpg" || ext === "jpeg"
         ? "image/jpeg"
         : ext === "png"
-          ? "image/png"
+        ? "image/png"
           : "image/jpeg";
-    const b64 = fs.readFileSync(filePath, "base64");
+    const imageBuffer = fs.readFileSync(filePath);
+    const b64 = imageBuffer.toString("base64");
     const dataUrl = `data:${mime};base64,${b64}`;
 
-    // Call GPT to extract tag info
     let parsed;
+    let cacheLookup = null;
+
     try {
-      parsed = await tagExtractor(dataUrl);
-    } catch {
-      return res.status(502).json({
-        error: {
-          code: "UPSTREAM_ERROR",
-          message: "Failed to analyze image with AI provider.",
-        },
-      });
+      cacheLookup = await lookup(imageBuffer);
+      cacheMetrics.mode = cacheLookup.mode || cacheMode;
+      cacheMetrics.embedder = cacheLookup.embedder || cacheMetrics.embedder;
+      cacheMetrics.status = cacheLookup.status;
+      cacheMetrics.similarity = formatSimilarity(cacheLookup.similarity);
+      cacheMetrics.embeddingMs = formatMs(cacheLookup.timing.embeddingMs);
+      cacheMetrics.lookupMs = formatMs(cacheLookup.timing.lookupMs);
+      if (cacheLookup.status !== "MISS") {
+        parsed = cacheLookup.parsed;
+      }
+    } catch (err) {
+      console.warn("[EcoTag] Cache lookup failed; continuing without cache.", err);
     }
+
+    if (!parsed) {
+      try {
+        if (isMockOcrEnabled()) {
+          parsed = extractMockTagFromImageBuffer(imageBuffer, cacheLookup?.artifacts);
+        } else {
+          parsed = await tagExtractor(dataUrl);
+        }
+      } catch {
+        applyCacheHeaders(res, cacheMetrics);
+        return res.status(502).json({
+          error: {
+            code: "UPSTREAM_ERROR",
+            message: "Failed to analyze image with AI provider.",
+          },
+        });
+      }
+
+      if (cacheLookup?.cacheEnabled) {
+        try {
+          await store({
+            imageBuffer,
+            parsed,
+            imageHash: cacheLookup?.artifacts?.imageHash,
+            fingerprint: cacheLookup?.artifacts?.fingerprint,
+          });
+        } catch (err) {
+          console.warn("[EcoTag] Cache write failed; skipping cache store.", err);
+        }
+      }
+      cacheMetrics.status = "MISS";
+      cacheMetrics.similarity = "";
+      cacheMetrics.falsePositive = "NA";
+    } else if (cacheLookup?.status === "HIT_SEMANTIC" && isMockOcrEnabled()) {
+      try {
+        const expected = extractMockTagFromImageBuffer(
+          imageBuffer,
+          cacheLookup?.artifacts,
+        );
+        cacheMetrics.falsePositive = isDeepStrictEqual(parsed, expected) ? "0" : "1";
+      } catch {
+        cacheMetrics.falsePositive = "NA";
+      }
+    }
+
+    // Normalize shape before emissions calculation.
     parsed = normalizeParsedForEmissions(parsed);
-    // Calculate emissions
-    let emissions;
+
     try {
+      let emissions;
       emissions = estimateEmissions(parsed);
+      applyCacheHeaders(res, cacheMetrics);
+      return res.json({ parsed, emissions });
     } catch (err) {
       if (
         err instanceof Error &&
         err.message.includes("Care instructions must be a structured object")
       ) {
-        emissions = estimateEmissions(withFallbackCareForEmissions(parsed));
-      } else {
-        throw err;
+        const emissions = estimateEmissions(withFallbackCareForEmissions(parsed));
+        applyCacheHeaders(res, cacheMetrics);
+        return res.json({ parsed, emissions });
       }
+      throw err;
     }
-
-    res.json({ parsed, emissions });
-  } catch {
+  } catch (err) {
+    console.error("[EcoTag] /api/tag failed with internal error.", err);
+    applyCacheHeaders(res, cacheMetrics);
     res.status(500).json({
       error: {
         code: "INTERNAL_ERROR",

--- a/backend/benchmarks/vlm_benchmark.js
+++ b/backend/benchmarks/vlm_benchmark.js
@@ -76,11 +76,80 @@ function percentile(values, p) {
   return Number(sorted[safeIdx].toFixed(2));
 }
 
+function mean(values) {
+  if (values.length === 0) return null;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return Number((total / values.length).toFixed(2));
+}
+
+function parseOptionalNumber(value) {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed;
+}
+
+function buildCacheResetUrl(tagUrl) {
+  const parsed = new URL(tagUrl);
+  const basePath = parsed.pathname.replace(/\/tag\/?$/, "");
+  parsed.pathname = `${basePath}/cache/reset`.replace(/\/{2,}/g, "/");
+  return parsed.toString();
+}
+
+async function resetRemoteCache({ tagUrl, timeoutMs }) {
+  const resetUrl = buildCacheResetUrl(tagUrl);
+  const response = await fetch(resetUrl, {
+    method: "POST",
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Cache reset failed (${response.status}) at ${resetUrl}`,
+    );
+  }
+
+  return {
+    url: resetUrl,
+    status: response.status,
+    body,
+  };
+}
+
 function summarize(results) {
   const latencies = results.map((r) => r.latencyMs);
   const successes = results.filter((r) => r.ok).length;
+  const exactHits = results.filter((r) => r.cacheStatus === "HIT_EXACT").length;
+  const semanticHits = results.filter((r) => r.cacheStatus === "HIT_SEMANTIC").length;
+  const semanticFalsePositives = results.filter(
+    (r) => r.cacheStatus === "HIT_SEMANTIC" && r.cacheFalsePositive === 1,
+  ).length;
+  const embeddingValues = results
+    .map((r) => r.cacheEmbeddingMs)
+    .filter((value) => Number.isFinite(value));
+  const lookupValues = results
+    .map((r) => r.cacheLookupMs)
+    .filter((value) => Number.isFinite(value));
+  const rssValues = results.map((r) => r.cacheRssMb).filter((value) => Number.isFinite(value));
+  const cacheModeCounts = results.reduce((acc, result) => {
+    const key = result.cacheMode || "unknown";
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+  const cacheEmbedderCounts = results.reduce((acc, result) => {
+    const key = result.cacheEmbedder || "unknown";
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
   const count = results.length;
-  const mean =
+  const latencyMean =
     count === 0
       ? null
       : Number((latencies.reduce((sum, v) => sum + v, 0) / count).toFixed(2));
@@ -90,12 +159,27 @@ function summarize(results) {
   return {
     count,
     success_rate: count === 0 ? 0 : Number(((successes / count) * 100).toFixed(2)),
-    mean_ms: mean,
+    mean_ms: latencyMean,
     p50_ms: percentile(latencies, 50),
     p95_ms: percentile(latencies, 95),
     p99_ms: percentile(latencies, 99),
     min_ms: min,
     max_ms: max,
+    exact_hit_rate: count === 0 ? 0 : Number(((exactHits / count) * 100).toFixed(2)),
+    semantic_hit_rate: count === 0 ? 0 : Number(((semanticHits / count) * 100).toFixed(2)),
+    overall_hit_rate:
+      count === 0 ? 0 : Number((((exactHits + semanticHits) / count) * 100).toFixed(2)),
+    semantic_false_positive_rate:
+      semanticHits === 0
+        ? 0
+        : Number(((semanticFalsePositives / semanticHits) * 100).toFixed(2)),
+    avg_embedding_ms: mean(embeddingValues),
+    avg_lookup_ms: mean(lookupValues),
+    rss_mb_avg: mean(rssValues),
+    rss_mb_max:
+      rssValues.length === 0 ? null : Number(Math.max(...rssValues).toFixed(2)),
+    cache_mode_counts: cacheModeCounts,
+    cache_embedder_counts: cacheEmbedderCounts,
   };
 }
 
@@ -115,6 +199,24 @@ async function runRequest({ url, imagePath, timeoutMs }) {
       body: form,
       signal: AbortSignal.timeout(timeoutMs),
     });
+    const cacheMode = response.headers.get("x-cache-mode") ?? "unknown";
+    const cacheEmbedder = response.headers.get("x-cache-embedder") ?? "unknown";
+    const cacheStatus = response.headers.get("x-cache-status") ?? "MISS";
+    const cacheSimilarity = parseOptionalNumber(
+      response.headers.get("x-cache-similarity"),
+    );
+    const cacheEmbeddingMs = parseOptionalNumber(
+      response.headers.get("x-cache-embedding-ms"),
+    );
+    const cacheLookupMs = parseOptionalNumber(response.headers.get("x-cache-lookup-ms"));
+    const falsePositiveHeader = response.headers.get("x-cache-false-positive");
+    const cacheFalsePositive =
+      falsePositiveHeader === "1"
+        ? 1
+        : falsePositiveHeader === "0"
+          ? 0
+          : null;
+    const cacheRssMb = parseOptionalNumber(response.headers.get("x-cache-rss-mb"));
 
     const latencyMs = Number(process.hrtime.bigint() - started) / 1e6;
     return {
@@ -122,6 +224,14 @@ async function runRequest({ url, imagePath, timeoutMs }) {
       status: response.status,
       latencyMs: Number(latencyMs.toFixed(2)),
       image: imagePath,
+      cacheMode,
+      cacheEmbedder,
+      cacheStatus,
+      cacheSimilarity,
+      cacheEmbeddingMs,
+      cacheLookupMs,
+      cacheFalsePositive,
+      cacheRssMb,
     };
   } catch {
     const latencyMs = Number(process.hrtime.bigint() - started) / 1e6;
@@ -130,6 +240,14 @@ async function runRequest({ url, imagePath, timeoutMs }) {
       status: 0,
       latencyMs: Number(latencyMs.toFixed(2)),
       image: imagePath,
+      cacheMode: "unknown",
+      cacheEmbedder: "unknown",
+      cacheStatus: "MISS",
+      cacheSimilarity: null,
+      cacheEmbeddingMs: null,
+      cacheLookupMs: null,
+      cacheFalsePositive: null,
+      cacheRssMb: null,
     };
   }
 }
@@ -154,6 +272,10 @@ async function runWithConcurrency({ runs, concurrency, requestFactory }) {
 
 async function main() {
   const opts = parseArgs(process.argv.slice(2));
+  const reset = await resetRemoteCache({
+    tagUrl: opts.url,
+    timeoutMs: Math.min(opts.timeoutMs, 15000),
+  });
   const images = await collectImages(opts);
 
   const results = await runWithConcurrency({
@@ -182,11 +304,16 @@ async function main() {
     generated_at: now.toISOString(),
     config: {
       url: opts.url,
+      cache_reset_url: reset.url,
       runs: opts.runs,
       concurrency: opts.concurrency,
       timeout_ms: opts.timeoutMs,
       image: opts.image,
       images_dir: opts.imagesDir,
+    },
+    cache_reset: {
+      status: reset.status,
+      response: reset.body,
     },
     summary,
     results,
@@ -196,6 +323,8 @@ async function main() {
 
   console.log("VLM Benchmark Results");
   console.log(`url: ${opts.url}`);
+  console.log(`cache_reset_url: ${reset.url}`);
+  console.log(`cache_reset_status: ${reset.status}`);
   console.log(`runs: ${summary.count}`);
   console.log(`success_rate: ${summary.success_rate}%`);
   console.log(`mean_ms: ${summary.mean_ms}`);
@@ -204,6 +333,20 @@ async function main() {
   console.log(`p99_ms: ${summary.p99_ms}`);
   console.log(`min_ms: ${summary.min_ms}`);
   console.log(`max_ms: ${summary.max_ms}`);
+  console.log(`exact_hit_rate: ${summary.exact_hit_rate}%`);
+  console.log(`semantic_hit_rate: ${summary.semantic_hit_rate}%`);
+  console.log(`overall_hit_rate: ${summary.overall_hit_rate}%`);
+  console.log(
+    `semantic_false_positive_rate: ${summary.semantic_false_positive_rate}%`,
+  );
+  console.log(`avg_embedding_ms: ${summary.avg_embedding_ms}`);
+  console.log(`avg_lookup_ms: ${summary.avg_lookup_ms}`);
+  console.log(`rss_mb_avg: ${summary.rss_mb_avg}`);
+  console.log(`rss_mb_max: ${summary.rss_mb_max}`);
+  console.log(`cache_mode_counts: ${JSON.stringify(summary.cache_mode_counts)}`);
+  console.log(
+    `cache_embedder_counts: ${JSON.stringify(summary.cache_embedder_counts)}`,
+  );
   console.log(`output: ${outputPath}`);
 }
 

--- a/backend/cache/config.js
+++ b/backend/cache/config.js
@@ -1,0 +1,92 @@
+function parseBoolean(value, fallback) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return fallback;
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function parseSimilarityThreshold(value, fallback) {
+  const parsed = Number.parseFloat(value ?? "");
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  if (parsed < 0) return 0;
+  if (parsed > 1) return 1;
+  return parsed;
+}
+
+function parseCacheMode(value, fallback) {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "exact" || normalized === "semantic" || normalized === "tiered") {
+    return normalized;
+  }
+  return fallback;
+}
+
+function parseSemanticEmbedder(value, fallback) {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "clip" || normalized === "fingerprint") {
+    return normalized;
+  }
+  return fallback;
+}
+
+function parseSemanticFallback(value, fallback) {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "none" || normalized === "fingerprint") {
+    return normalized;
+  }
+  return fallback;
+}
+
+export function getCacheConfig() {
+  return {
+    cacheEnabled: parseBoolean(process.env.CACHE_ENABLED, true),
+    cacheDbPath: process.env.CACHE_DB_PATH?.trim() || "./cache/ecotag-cache.sqlite",
+    similarityThreshold: parseSimilarityThreshold(
+      process.env.CACHE_SIMILARITY_THRESHOLD,
+      0.9,
+    ),
+    cacheMaxEntries: parsePositiveInt(process.env.CACHE_MAX_ENTRIES, 5000),
+    fingerprintVersion: process.env.CACHE_FINGERPRINT_VERSION?.trim() || "v1",
+    cacheMode: parseCacheMode(process.env.CACHE_MODE, "tiered"),
+    semanticEmbedder: parseSemanticEmbedder(
+      process.env.CACHE_SEMANTIC_EMBEDDER,
+      "clip",
+    ),
+    semanticClipModel:
+      process.env.CACHE_SEMANTIC_CLIP_MODEL?.trim() ||
+      "Xenova/clip-vit-base-patch32",
+    semanticFallbackEmbedder: parseSemanticFallback(
+      process.env.CACHE_SEMANTIC_FALLBACK,
+      "none",
+    ),
+    mockOcrEnabled: parseBoolean(process.env.MOCK_OCR, false),
+  };
+}
+
+export function isMockOcrEnabled() {
+  return getCacheConfig().mockOcrEnabled;
+}

--- a/backend/cache/db.js
+++ b/backend/cache/db.js
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { getCacheConfig } from "./config.js";
+
+let dbPath = null;
+let db = null;
+
+function initSchema(database) {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS cache_entries (
+      id INTEGER PRIMARY KEY,
+      image_hash TEXT UNIQUE NOT NULL,
+      fingerprint_version TEXT NOT NULL,
+      fingerprint_json TEXT NOT NULL,
+      parsed_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      last_hit_at INTEGER,
+      hit_count INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_cache_entries_created_at
+      ON cache_entries(created_at);
+  `);
+}
+
+function ensureDb() {
+  const resolvedPath = path.resolve(getCacheConfig().cacheDbPath);
+  if (db && dbPath === resolvedPath) {
+    return db;
+  }
+
+  if (db) {
+    db.close();
+  }
+
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  db = new Database(resolvedPath);
+  dbPath = resolvedPath;
+  initSchema(db);
+  return db;
+}
+
+export function closeCacheDbForTest() {
+  if (!db) return;
+  db.close();
+  db = null;
+  dbPath = null;
+}
+
+export function getExactEntry({ imageHash, fingerprintVersion }) {
+  const database = ensureDb();
+  return database
+    .prepare(
+      `SELECT id, image_hash, fingerprint_json, parsed_json, created_at, last_hit_at, hit_count
+       FROM cache_entries
+       WHERE image_hash = ? AND fingerprint_version = ?`,
+    )
+    .get(imageHash, fingerprintVersion);
+}
+
+export function listVersionEntries(fingerprintVersion) {
+  const database = ensureDb();
+  return database
+    .prepare(
+      `SELECT id, image_hash, fingerprint_json, parsed_json, created_at, last_hit_at, hit_count
+       FROM cache_entries
+       WHERE fingerprint_version = ?`,
+    )
+    .all(fingerprintVersion);
+}
+
+export function touchEntry(id) {
+  const database = ensureDb();
+  database
+    .prepare(
+      `UPDATE cache_entries
+       SET last_hit_at = ?, hit_count = hit_count + 1
+       WHERE id = ?`,
+    )
+    .run(Date.now(), id);
+}
+
+export function upsertEntry({
+  imageHash,
+  fingerprintVersion,
+  fingerprintJson,
+  parsedJson,
+  createdAt = Date.now(),
+}) {
+  const database = ensureDb();
+  database
+    .prepare(
+      `INSERT INTO cache_entries (
+         image_hash,
+         fingerprint_version,
+         fingerprint_json,
+         parsed_json,
+         created_at,
+         last_hit_at,
+         hit_count
+       ) VALUES (?, ?, ?, ?, ?, NULL, 0)
+       ON CONFLICT(image_hash) DO UPDATE SET
+         fingerprint_version = excluded.fingerprint_version,
+         fingerprint_json = excluded.fingerprint_json,
+         parsed_json = excluded.parsed_json,
+         created_at = excluded.created_at`,
+    )
+    .run(imageHash, fingerprintVersion, fingerprintJson, parsedJson, createdAt);
+}
+
+export function countEntries() {
+  const database = ensureDb();
+  const row = database.prepare("SELECT COUNT(*) AS count FROM cache_entries").get();
+  return Number(row?.count ?? 0);
+}
+
+export function pruneOldestEntries(excessCount) {
+  if (!Number.isInteger(excessCount) || excessCount <= 0) return;
+  const database = ensureDb();
+  database
+    .prepare(
+      `DELETE FROM cache_entries
+       WHERE id IN (
+         SELECT id
+         FROM cache_entries
+         ORDER BY created_at ASC, id ASC
+         LIMIT ?
+       )`,
+    )
+    .run(excessCount);
+}
+
+export function clearEntries() {
+  const database = ensureDb();
+  database.prepare("DELETE FROM cache_entries").run();
+}
+
+export function insertEntryForTest({
+  imageHash,
+  fingerprintVersion,
+  fingerprint,
+  parsed,
+  createdAt = Date.now(),
+}) {
+  const fingerprintJson = JSON.stringify(fingerprint);
+  const parsedJson = JSON.stringify(parsed);
+  const database = ensureDb();
+  database
+    .prepare(
+      `INSERT OR REPLACE INTO cache_entries (
+         image_hash,
+         fingerprint_version,
+         fingerprint_json,
+         parsed_json,
+         created_at,
+         last_hit_at,
+         hit_count
+       ) VALUES (?, ?, ?, ?, ?, NULL, 0)`,
+    )
+    .run(imageHash, fingerprintVersion, fingerprintJson, parsedJson, createdAt);
+}

--- a/backend/cache/embedding.js
+++ b/backend/cache/embedding.js
@@ -1,0 +1,173 @@
+import { getCacheConfig } from "./config.js";
+import { computeFingerprint } from "./fingerprint.js";
+
+let clipExtractorPromise = null;
+let clipExtractorModel = null;
+let warnedFallback = false;
+
+function normalizeVector(values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error("Embedding vector is empty");
+  }
+  const norm = Math.sqrt(values.reduce((sum, value) => sum + value * value, 0));
+  if (!Number.isFinite(norm) || norm === 0) {
+    throw new Error("Embedding vector norm is invalid");
+  }
+  return values.map((value) => Number((value / norm).toFixed(8)));
+}
+
+function flattenArray(value, out = []) {
+  if (Array.isArray(value)) {
+    for (const child of value) {
+      flattenArray(child, out);
+    }
+  } else if (Number.isFinite(value)) {
+    out.push(Number(value));
+  }
+  return out;
+}
+
+function averageTokenEmbeddings(data, dims) {
+  if (!Array.isArray(dims) || dims.length < 2) {
+    return data;
+  }
+
+  const hidden = Number(dims[dims.length - 1]);
+  if (!Number.isInteger(hidden) || hidden <= 0) {
+    return data;
+  }
+  if (data.length === hidden) {
+    return data;
+  }
+  if (data.length % hidden !== 0) {
+    return data;
+  }
+
+  const tokenCount = data.length / hidden;
+  const pooled = new Array(hidden).fill(0);
+  for (let token = 0; token < tokenCount; token += 1) {
+    const offset = token * hidden;
+    for (let i = 0; i < hidden; i += 1) {
+      pooled[i] += data[offset + i];
+    }
+  }
+
+  for (let i = 0; i < hidden; i += 1) {
+    pooled[i] /= tokenCount;
+  }
+  return pooled;
+}
+
+function extractVectorFromOutput(output) {
+  if (output && typeof output === "object") {
+    if (ArrayBuffer.isView(output.data)) {
+      const data = Array.from(output.data, (value) => Number(value));
+      return averageTokenEmbeddings(data, output.dims);
+    }
+    if (typeof output.tolist === "function") {
+      return flattenArray(output.tolist());
+    }
+  }
+
+  if (Array.isArray(output)) {
+    return flattenArray(output);
+  }
+
+  throw new Error("Unexpected CLIP output format");
+}
+
+async function getClipExtractor(model) {
+  if (clipExtractorPromise && clipExtractorModel === model) {
+    return clipExtractorPromise;
+  }
+
+  clipExtractorModel = model;
+  clipExtractorPromise = (async () => {
+    let transformers;
+    try {
+      transformers = await import("@xenova/transformers");
+    } catch (err) {
+      throw new Error(
+        "Missing '@xenova/transformers'. Run `npm install` in backend.",
+      );
+    }
+
+    const { pipeline } = transformers;
+    const extractor = await pipeline("image-feature-extraction", model);
+    return { extractor, transformers };
+  })().catch((err) => {
+    clipExtractorPromise = null;
+    clipExtractorModel = null;
+    throw err;
+  });
+
+  return clipExtractorPromise;
+}
+
+async function runClipExtraction({ imageBuffer, model }) {
+  const { extractor, transformers } = await getClipExtractor(model);
+  const { RawImage } = transformers;
+  const options = { pooling: "mean", normalize: true };
+
+  if (RawImage && typeof RawImage.fromBlob === "function") {
+    try {
+      const blob = new Blob([imageBuffer]);
+      const rawImage = await RawImage.fromBlob(blob);
+      return await extractor(rawImage, options);
+    } catch {
+      // Fall through to other input forms.
+    }
+  }
+
+  if (RawImage && typeof RawImage.read === "function") {
+    try {
+      const rawImage = await RawImage.read(imageBuffer);
+      return await extractor(rawImage, options);
+    } catch {
+      // Fall through to direct buffer input.
+    }
+  }
+
+  try {
+    return await extractor(imageBuffer, options);
+  } catch {
+    return extractor(new Uint8Array(imageBuffer), options);
+  }
+}
+
+export async function computeSemanticEmbedding(imageBuffer) {
+  const config = getCacheConfig();
+
+  if (config.semanticEmbedder === "fingerprint") {
+    return {
+      embedder: "fingerprint",
+      vector: computeFingerprint(imageBuffer),
+    };
+  }
+
+  try {
+    const output = await runClipExtraction({
+      imageBuffer,
+      model: config.semanticClipModel,
+    });
+    const vector = normalizeVector(extractVectorFromOutput(output));
+    return {
+      embedder: "clip",
+      vector,
+    };
+  } catch (err) {
+    if (config.semanticFallbackEmbedder === "fingerprint") {
+      if (!warnedFallback) {
+        warnedFallback = true;
+        console.warn(
+          "[EcoTag] CLIP embedder failed; falling back to fingerprint embedder.",
+        );
+      }
+      return {
+        embedder: "fingerprint_fallback",
+        vector: computeFingerprint(imageBuffer),
+      };
+    }
+    throw err;
+  }
+}

--- a/backend/cache/fingerprint.js
+++ b/backend/cache/fingerprint.js
@@ -1,0 +1,128 @@
+import crypto from "node:crypto";
+import jpeg from "jpeg-js";
+import { PNG } from "pngjs";
+
+const TARGET_WIDTH = 32;
+const TARGET_HEIGHT = 32;
+const BLOCKS = 8;
+
+function isPng(buffer) {
+  return (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  );
+}
+
+function isJpeg(buffer) {
+  return buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xd8;
+}
+
+function decodeToRgba(buffer) {
+  if (isPng(buffer)) {
+    const png = PNG.sync.read(buffer);
+    return { data: png.data, width: png.width, height: png.height };
+  }
+
+  if (isJpeg(buffer)) {
+    const jpg = jpeg.decode(buffer, { useTArray: true });
+    return { data: jpg.data, width: jpg.width, height: jpg.height };
+  }
+
+  throw new Error("Unsupported image format for fingerprinting");
+}
+
+function toGrayscale(rgba, width, height) {
+  const out = new Float64Array(width * height);
+  for (let i = 0; i < width * height; i += 1) {
+    const offset = i * 4;
+    const r = rgba[offset];
+    const g = rgba[offset + 1];
+    const b = rgba[offset + 2];
+    out[i] = 0.299 * r + 0.587 * g + 0.114 * b;
+  }
+  return out;
+}
+
+function resizeNearest(src, srcWidth, srcHeight, dstWidth, dstHeight) {
+  const out = new Float64Array(dstWidth * dstHeight);
+  for (let y = 0; y < dstHeight; y += 1) {
+    const srcY = Math.min(srcHeight - 1, Math.floor((y * srcHeight) / dstHeight));
+    for (let x = 0; x < dstWidth; x += 1) {
+      const srcX = Math.min(srcWidth - 1, Math.floor((x * srcWidth) / dstWidth));
+      out[y * dstWidth + x] = src[srcY * srcWidth + srcX];
+    }
+  }
+  return out;
+}
+
+function normalizeVector(values) {
+  const norm = Math.sqrt(values.reduce((sum, value) => sum + value * value, 0));
+  if (norm === 0) {
+    return values.map(() => 0);
+  }
+  return values.map((value) => Number((value / norm).toFixed(8)));
+}
+
+export function computeImageHash(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+export function computeFingerprint(buffer) {
+  const { data, width, height } = decodeToRgba(buffer);
+  const grayscale = toGrayscale(data, width, height);
+  const resized = resizeNearest(
+    grayscale,
+    width,
+    height,
+    TARGET_WIDTH,
+    TARGET_HEIGHT,
+  );
+
+  const blockSizeX = TARGET_WIDTH / BLOCKS;
+  const blockSizeY = TARGET_HEIGHT / BLOCKS;
+  const vector = [];
+
+  for (let by = 0; by < BLOCKS; by += 1) {
+    for (let bx = 0; bx < BLOCKS; bx += 1) {
+      let sum = 0;
+      for (let y = 0; y < blockSizeY; y += 1) {
+        for (let x = 0; x < blockSizeX; x += 1) {
+          const px = bx * blockSizeX + x;
+          const py = by * blockSizeY + y;
+          sum += resized[py * TARGET_WIDTH + px];
+        }
+      }
+      const avg = sum / (blockSizeX * blockSizeY * 255);
+      vector.push(avg);
+    }
+  }
+
+  return normalizeVector(vector);
+}
+
+export function cosineSimilarity(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length || a.length === 0) {
+    throw new Error("Cosine similarity requires same-length non-empty arrays");
+  }
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+  return dot / Math.sqrt(normA * normB);
+}

--- a/backend/cache/service.js
+++ b/backend/cache/service.js
@@ -1,0 +1,382 @@
+import {
+  clearEntries,
+  closeCacheDbForTest,
+  countEntries,
+  getExactEntry,
+  insertEntryForTest,
+  listVersionEntries,
+  pruneOldestEntries,
+  touchEntry,
+  upsertEntry,
+} from "./db.js";
+import { getCacheConfig } from "./config.js";
+import { computeImageHash, cosineSimilarity } from "./fingerprint.js";
+import { computeSemanticEmbedding } from "./embedding.js";
+
+function safeParse(jsonValue) {
+  try {
+    return JSON.parse(jsonValue);
+  } catch {
+    return null;
+  }
+}
+
+function createMissResult({
+  cacheEnabled,
+  mode,
+  embedder,
+  embeddingMs = 0,
+  lookupMs = 0,
+  artifacts = null,
+}) {
+  return {
+    cacheEnabled,
+    mode,
+    embedder,
+    status: "MISS",
+    parsed: null,
+    similarity: null,
+    timing: {
+      embeddingMs: Number(embeddingMs.toFixed(2)),
+      lookupMs: Number(lookupMs.toFixed(2)),
+    },
+    artifacts,
+  };
+}
+
+function runExactLookup({ imageHash, config }) {
+  const exact = getExactEntry({
+    imageHash,
+    fingerprintVersion: config.fingerprintVersion,
+  });
+  if (exact) {
+    const parsed = safeParse(exact.parsed_json);
+    if (parsed !== null) {
+      touchEntry(exact.id);
+      return {
+        status: "HIT_EXACT",
+        parsed,
+        similarity: null,
+      };
+    }
+  }
+
+  return {
+    status: "MISS",
+    parsed: null,
+    similarity: null,
+  };
+}
+
+function runSemanticLookup({ imageHash, fingerprint, config, skipSameHash = false }) {
+  const rows = listVersionEntries(config.fingerprintVersion);
+  let best = null;
+
+  for (const row of rows) {
+    if (skipSameHash && row.image_hash === imageHash) continue;
+
+    const candidateFingerprint = safeParse(row.fingerprint_json);
+    if (!Array.isArray(candidateFingerprint) || candidateFingerprint.length !== fingerprint.length) {
+      continue;
+    }
+
+    const similarity = cosineSimilarity(fingerprint, candidateFingerprint);
+    if (!Number.isFinite(similarity)) continue;
+    if (!best || similarity > best.similarity) {
+      best = { row, similarity };
+    }
+  }
+
+  if (best && best.similarity >= config.similarityThreshold) {
+    const parsed = safeParse(best.row.parsed_json);
+    if (parsed !== null) {
+      touchEntry(best.row.id);
+      return {
+        status: "HIT_SEMANTIC",
+        parsed,
+        similarity: Number(best.similarity.toFixed(6)),
+      };
+    }
+  }
+
+  return {
+    status: "MISS",
+    parsed: null,
+    similarity: null,
+  };
+}
+
+function runTieredLookup({ imageHash, fingerprint, config }) {
+  const exact = runExactLookup({ imageHash, config });
+  if (exact.status !== "MISS") {
+    return exact;
+  }
+
+  return runSemanticLookup({
+    imageHash,
+    fingerprint,
+    config,
+    skipSameHash: true,
+  });
+}
+
+function pruneToMaxEntries(maxEntries) {
+  const total = countEntries();
+  const excess = total - maxEntries;
+  if (excess > 0) {
+    pruneOldestEntries(excess);
+  }
+}
+
+export async function lookup(imageBuffer) {
+  const config = getCacheConfig();
+  const mode = config.cacheMode;
+  if (!config.cacheEnabled) {
+    return createMissResult({ cacheEnabled: false, mode, embedder: "none" });
+  }
+
+  const imageHash = computeImageHash(imageBuffer);
+
+  if (mode === "exact") {
+    const lookupStart = process.hrtime.bigint();
+    const lookupResult = runExactLookup({ imageHash, config });
+    const lookupMs = Number(process.hrtime.bigint() - lookupStart) / 1e6;
+
+    if (lookupResult.status === "MISS") {
+      return createMissResult({
+        cacheEnabled: true,
+        mode,
+        embedder: "none",
+        embeddingMs: 0,
+        lookupMs,
+        artifacts: { imageHash, fingerprint: null },
+      });
+    }
+
+    return {
+      cacheEnabled: true,
+      mode,
+      embedder: "none",
+      status: lookupResult.status,
+      parsed: lookupResult.parsed,
+      similarity: lookupResult.similarity,
+      timing: {
+        embeddingMs: 0,
+        lookupMs: Number(lookupMs.toFixed(2)),
+      },
+      artifacts: { imageHash, fingerprint: null },
+    };
+  }
+
+  if (mode === "tiered") {
+    const exactLookupStart = process.hrtime.bigint();
+    const exactLookupResult = runExactLookup({ imageHash, config });
+    const exactLookupMs = Number(process.hrtime.bigint() - exactLookupStart) / 1e6;
+
+    if (exactLookupResult.status !== "MISS") {
+      return {
+        cacheEnabled: true,
+        mode,
+        embedder: "none",
+        status: exactLookupResult.status,
+        parsed: exactLookupResult.parsed,
+        similarity: exactLookupResult.similarity,
+        timing: {
+          embeddingMs: 0,
+          lookupMs: Number(exactLookupMs.toFixed(2)),
+        },
+        artifacts: { imageHash, fingerprint: null },
+      };
+    }
+
+    const embeddingStart = process.hrtime.bigint();
+    const semanticEmbedding = await computeSemanticEmbedding(imageBuffer);
+    const fingerprint = semanticEmbedding.vector;
+    const embeddingMs = Number(process.hrtime.bigint() - embeddingStart) / 1e6;
+
+    const semanticLookupStart = process.hrtime.bigint();
+    const semanticLookupResult = runSemanticLookup({
+      imageHash,
+      fingerprint,
+      config,
+      skipSameHash: true,
+    });
+    const semanticLookupMs =
+      Number(process.hrtime.bigint() - semanticLookupStart) / 1e6;
+    const lookupMs = exactLookupMs + semanticLookupMs;
+
+    if (semanticLookupResult.status === "MISS") {
+      return createMissResult({
+        cacheEnabled: true,
+        mode,
+        embedder: semanticEmbedding.embedder,
+        embeddingMs,
+        lookupMs,
+        artifacts: { imageHash, fingerprint },
+      });
+    }
+
+    return {
+      cacheEnabled: true,
+      mode,
+      embedder: semanticEmbedding.embedder,
+      status: semanticLookupResult.status,
+      parsed: semanticLookupResult.parsed,
+      similarity: semanticLookupResult.similarity,
+      timing: {
+        embeddingMs: Number(embeddingMs.toFixed(2)),
+        lookupMs: Number(lookupMs.toFixed(2)),
+      },
+      artifacts: { imageHash, fingerprint },
+    };
+  }
+
+  const embeddingStart = process.hrtime.bigint();
+  const semanticEmbedding = await computeSemanticEmbedding(imageBuffer);
+  const fingerprint = semanticEmbedding.vector;
+  const embeddingMs = Number(process.hrtime.bigint() - embeddingStart) / 1e6;
+
+  const lookupStart = process.hrtime.bigint();
+  const lookupResult = runSemanticLookup({
+    imageHash,
+    fingerprint,
+    config,
+    skipSameHash: false,
+  });
+  const lookupMs = Number(process.hrtime.bigint() - lookupStart) / 1e6;
+
+  if (lookupResult.status === "MISS") {
+    return createMissResult({
+      cacheEnabled: true,
+      mode,
+      embedder: semanticEmbedding.embedder,
+      embeddingMs,
+      lookupMs,
+      artifacts: { imageHash, fingerprint },
+    });
+  }
+
+  return {
+    cacheEnabled: true,
+    mode,
+    embedder: semanticEmbedding.embedder,
+    status: lookupResult.status,
+    parsed: lookupResult.parsed,
+    similarity: lookupResult.similarity,
+    timing: {
+      embeddingMs: Number(embeddingMs.toFixed(2)),
+      lookupMs: Number(lookupMs.toFixed(2)),
+    },
+    artifacts: { imageHash, fingerprint },
+  };
+}
+
+export function __lookupWithArtifactsForTest({ imageHash, fingerprint }) {
+  const config = getCacheConfig();
+  const mode = config.cacheMode;
+  if (!config.cacheEnabled) {
+    return createMissResult({ cacheEnabled: false, mode, embedder: "none" });
+  }
+
+  const lookupStart = process.hrtime.bigint();
+  const lookupResult =
+    mode === "exact"
+      ? runExactLookup({ imageHash, config })
+      : mode === "semantic"
+        ? runSemanticLookup({ imageHash, fingerprint, config, skipSameHash: false })
+        : runTieredLookup({ imageHash, fingerprint, config });
+  const lookupMs = Number(process.hrtime.bigint() - lookupStart) / 1e6;
+
+  if (lookupResult.status === "MISS") {
+    return createMissResult({
+      cacheEnabled: true,
+      mode,
+      embedder: "test",
+      embeddingMs: 0,
+      lookupMs,
+      artifacts: { imageHash, fingerprint },
+    });
+  }
+
+  return {
+    cacheEnabled: true,
+    mode,
+    embedder: "test",
+    status: lookupResult.status,
+    parsed: lookupResult.parsed,
+    similarity: lookupResult.similarity,
+    timing: {
+      embeddingMs: 0,
+      lookupMs: Number(lookupMs.toFixed(2)),
+    },
+    artifacts: { imageHash, fingerprint },
+  };
+}
+
+export async function store({ imageBuffer, parsed, imageHash, fingerprint }) {
+  const config = getCacheConfig();
+  const mode = config.cacheMode;
+  if (!config.cacheEnabled) {
+    return;
+  }
+
+  const resolvedHash = imageHash ?? computeImageHash(imageBuffer);
+  let resolvedFingerprint = [];
+  if (mode !== "exact") {
+    if (fingerprint) {
+      resolvedFingerprint = fingerprint;
+    } else {
+      const semanticEmbedding = await computeSemanticEmbedding(imageBuffer);
+      resolvedFingerprint = semanticEmbedding.vector;
+    }
+  }
+  upsertEntry({
+    imageHash: resolvedHash,
+    fingerprintVersion: config.fingerprintVersion,
+    fingerprintJson: JSON.stringify(resolvedFingerprint),
+    parsedJson: JSON.stringify(parsed),
+    createdAt: Date.now(),
+  });
+  pruneToMaxEntries(config.cacheMaxEntries);
+}
+
+export function resetCacheEntries() {
+  clearEntries();
+}
+
+export function countCacheEntries() {
+  return countEntries();
+}
+
+export function __resetCacheForTest() {
+  clearEntries();
+}
+
+export function __insertCacheEntryForTest({
+  imageHash,
+  fingerprint,
+  parsed,
+  createdAt = Date.now(),
+  fingerprintVersion,
+}) {
+  const config = getCacheConfig();
+  insertEntryForTest({
+    imageHash,
+    fingerprintVersion: fingerprintVersion ?? config.fingerprintVersion,
+    fingerprint,
+    parsed,
+    createdAt,
+  });
+}
+
+export function __countCacheEntriesForTest() {
+  return countEntries();
+}
+
+export function __pruneToMaxEntriesForTest(maxEntries) {
+  pruneToMaxEntries(maxEntries);
+}
+
+export function __closeCacheForTest() {
+  closeCacheDbForTest();
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5,15 +5,28 @@
   "packages": {
     "": {
       "dependencies": {
+        "@xenova/transformers": "^2.17.2",
         "axios": "^1.13.5",
+        "better-sqlite3": "^11.8.1",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "form-data": "^4.0.5",
+        "jpeg-js": "^0.4.4",
         "multer": "^2.0.2",
-        "openai": "^6.22.0"
+        "openai": "^6.22.0",
+        "pngjs": "^7.0.0"
       },
       "devDependencies": {
         "supertest": "^7.1.4"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@noble/hashes": {
@@ -37,6 +50,99 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
+      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@xenova/transformers": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.2.2",
+        "onnxruntime-web": "1.14.0",
+        "sharp": "^0.32.0"
+      },
+      "optionalDependencies": {
+        "onnxruntime-node": "1.14.0"
       }
     },
     "node_modules/accepts": {
@@ -82,6 +188,163 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.4.tgz",
+      "integrity": "sha512-POK4oplfA7P7gqvetNmCs4CNtm9fNsx+IAh7jH7GgU0OJdge2rso0R20TNWVq6VoWcCvsTdlNDaleLHGaKx8CA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
+      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -104,6 +367,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -159,6 +446,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "node_modules/combined-stream": {
@@ -262,6 +596,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -278,6 +636,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dezalgo": {
@@ -330,6 +697,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -392,6 +768,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -435,11 +829,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
     "node_modules/finalhandler": {
@@ -462,6 +868,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -556,6 +968,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -602,6 +1020,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -613,6 +1037,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -689,10 +1119,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -704,11 +1160,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -788,6 +1262,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -808,6 +1294,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -876,6 +1368,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -884,6 +1382,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -927,6 +1443,50 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onnx-proto": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^4.0.0",
+        "onnx-proto": "^4.0.4",
+        "onnxruntime-common": "~1.14.0",
+        "platform": "^1.3.6"
+      }
+    },
     "node_modules/openai": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
@@ -967,6 +1527,74 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -985,6 +1613,16 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -1023,6 +1661,21 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -1081,6 +1734,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -1131,6 +1796,54 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1204,6 +1917,60 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1221,6 +1988,17 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1228,6 +2006,15 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/superagent": {
@@ -1266,6 +2053,53 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1273,6 +2107,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -1293,6 +2139,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,16 +1,21 @@
 {
   "type": "module",
   "scripts": {
-    "test": "npm run test:e2e",
-    "test:e2e": "node --test --test-concurrency=1 test/e2e/*.test.js"
+    "test": "npm run test:e2e && npm run test:unit",
+    "test:e2e": "node --test --test-concurrency=1 test/e2e/*.test.js",
+    "test:unit": "node --test --test-concurrency=1 test/unit/*.test.js"
   },
   "dependencies": {
+    "@xenova/transformers": "^2.17.2",
     "axios": "^1.13.5",
+    "better-sqlite3": "^11.8.1",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "form-data": "^4.0.5",
+    "jpeg-js": "^0.4.4",
     "multer": "^2.0.2",
-    "openai": "^6.22.0"
+    "openai": "^6.22.0",
+    "pngjs": "^7.0.0"
   },
   "devDependencies": {
     "supertest": "^7.1.4"

--- a/backend/test/unit/cache.service.test.js
+++ b/backend/test/unit/cache.service.test.js
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  __closeCacheForTest,
+  __countCacheEntriesForTest,
+  __insertCacheEntryForTest,
+  __lookupWithArtifactsForTest,
+  __pruneToMaxEntriesForTest,
+  __resetCacheForTest,
+} from "../../cache/service.js";
+
+const originalEnv = {
+  CACHE_ENABLED: process.env.CACHE_ENABLED,
+  CACHE_DB_PATH: process.env.CACHE_DB_PATH,
+  CACHE_SIMILARITY_THRESHOLD: process.env.CACHE_SIMILARITY_THRESHOLD,
+  CACHE_MAX_ENTRIES: process.env.CACHE_MAX_ENTRIES,
+  CACHE_FINGERPRINT_VERSION: process.env.CACHE_FINGERPRINT_VERSION,
+};
+
+function buildFingerprint(primary, secondary = 0) {
+  const vec = new Array(64).fill(0);
+  vec[0] = primary;
+  vec[1] = secondary;
+  return vec;
+}
+
+function validParsed(country = "Portugal") {
+  return {
+    country,
+    materials: [{ fiber: "Cotton", pct: 100 }],
+    care: {
+      washing: "machine_wash_cold",
+      drying: "line_dry",
+      ironing: "iron_low",
+      dry_cleaning: null,
+    },
+  };
+}
+
+test.beforeEach(() => {
+  process.env.CACHE_ENABLED = "1";
+  process.env.CACHE_DB_PATH = "./cache/test-cache-service.sqlite";
+  process.env.CACHE_SIMILARITY_THRESHOLD = "0.9";
+  process.env.CACHE_MAX_ENTRIES = "5000";
+  process.env.CACHE_FINGERPRINT_VERSION = "unit-v1";
+  __resetCacheForTest();
+});
+
+test.after(() => {
+  __resetCacheForTest();
+  __closeCacheForTest();
+  process.env.CACHE_ENABLED = originalEnv.CACHE_ENABLED;
+  process.env.CACHE_DB_PATH = originalEnv.CACHE_DB_PATH;
+  process.env.CACHE_SIMILARITY_THRESHOLD = originalEnv.CACHE_SIMILARITY_THRESHOLD;
+  process.env.CACHE_MAX_ENTRIES = originalEnv.CACHE_MAX_ENTRIES;
+  process.env.CACHE_FINGERPRINT_VERSION = originalEnv.CACHE_FINGERPRINT_VERSION;
+});
+
+test("semantic lookup returns HIT_SEMANTIC above threshold", () => {
+  __insertCacheEntryForTest({
+    imageHash: "a".repeat(64),
+    fingerprint: buildFingerprint(1, 0),
+    parsed: validParsed("Portugal"),
+    createdAt: 1,
+  });
+
+  const query = buildFingerprint(0.95, Math.sqrt(1 - 0.95 * 0.95));
+  const result = __lookupWithArtifactsForTest({
+    imageHash: "b".repeat(64),
+    fingerprint: query,
+  });
+
+  assert.equal(result.status, "HIT_SEMANTIC");
+  assert.ok((result.similarity ?? 0) >= 0.9);
+  assert.equal(result.parsed?.country, "Portugal");
+});
+
+test("semantic lookup returns MISS below threshold", () => {
+  __insertCacheEntryForTest({
+    imageHash: "c".repeat(64),
+    fingerprint: buildFingerprint(1, 0),
+    parsed: validParsed("Italy"),
+    createdAt: 1,
+  });
+
+  const query = buildFingerprint(0.2, Math.sqrt(1 - 0.2 * 0.2));
+  const result = __lookupWithArtifactsForTest({
+    imageHash: "d".repeat(64),
+    fingerprint: query,
+  });
+
+  assert.equal(result.status, "MISS");
+});
+
+test("prune removes oldest rows when cache exceeds max", () => {
+  __insertCacheEntryForTest({
+    imageHash: "1".repeat(64),
+    fingerprint: buildFingerprint(1, 0),
+    parsed: validParsed("Portugal"),
+    createdAt: 1,
+  });
+  __insertCacheEntryForTest({
+    imageHash: "2".repeat(64),
+    fingerprint: buildFingerprint(0.8, 0.2),
+    parsed: validParsed("Italy"),
+    createdAt: 2,
+  });
+  __insertCacheEntryForTest({
+    imageHash: "3".repeat(64),
+    fingerprint: buildFingerprint(0.6, 0.4),
+    parsed: validParsed("Morocco"),
+    createdAt: 3,
+  });
+
+  __pruneToMaxEntriesForTest(2);
+  assert.equal(__countCacheEntriesForTest(), 2);
+
+  const oldestLookup = __lookupWithArtifactsForTest({
+    imageHash: "z".repeat(64),
+    fingerprint: buildFingerprint(1, 0),
+  });
+  assert.notEqual(oldestLookup.parsed?.country, "Portugal");
+});

--- a/backend/test/unit/fingerprint.test.js
+++ b/backend/test/unit/fingerprint.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  computeFingerprint,
+  computeImageHash,
+  cosineSimilarity,
+} from "../../cache/fingerprint.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixtureImage = path.resolve(__dirname, "../test_image.jpg");
+
+test("computeImageHash is deterministic for same image bytes", () => {
+  const image = fs.readFileSync(fixtureImage);
+  const hashA = computeImageHash(image);
+  const hashB = computeImageHash(image);
+  assert.equal(hashA, hashB);
+});
+
+test("computeFingerprint is deterministic and returns 64 dimensions", () => {
+  const image = fs.readFileSync(fixtureImage);
+  const fpA = computeFingerprint(image);
+  const fpB = computeFingerprint(image);
+
+  assert.equal(fpA.length, 64);
+  assert.deepEqual(fpA, fpB);
+});
+
+test("cosineSimilarity behaves correctly on simple vectors", () => {
+  assert.equal(cosineSimilarity([1, 0], [0, 1]), 0);
+  assert.equal(cosineSimilarity([1, 2, 3], [1, 2, 3]), 1);
+});

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -71,3 +71,27 @@ Optimize the Loop: We can drop latency by running the 5 variants in parallel or 
 **Parallelization:** Python's multiprocessing could allow us to run the 5 filters simultaneously, potentially capping latency.
 
 **Test Different CPUs**: Utilizing
+
+# Cache Benchmark Summary
+
+Run settings: 200 runs, concurrency 4.
+
+Key formulas:
+- `latency_overhead_ms = avg_embedding_ms + avg_lookup_ms`
+- `overall_wrong_response_rate = semantic_false_positive_count / runs`
+
+|            Metric            | No Cache        | Exact           | Semantic + CLIP | Tiered          |                  Notes                 |
+|:----------------------------:|-----------------|-----------------|-----------------|-----------------|:--------------------------------------:|
+| Success Rate                 | 100%            | 100%            | 100%            | 100%            | 200 / 200 successful runs each         |
+| Mean Latency (ms)            | 1706.34         | 877.16          | 703.93          | 457.98          | Tiered fastest overall                 |
+| Overall Hit Rate             | 0%              | 62%             | 63%             | 63%             | Semantic and tiered tied on hit rate   |
+| Miss Rate                    | 100%            | 38%             | 37%             | 37%             | —                                      |
+| Exact Hit Rate / Count       | 0% / 0          | 62% / 124       | 0% / 0          | 60% / 120       | —                                      |
+| Semantic Hit Rate / Count    | 0% / 0          | 0% / 0          | 63% / 126       | 3% / 6          | Tiered semantic fallback minimal       |
+| Semantic False Positive Rate | N/A             | N/A             | 4.76%           | 100%            | Tiered semantic layer noisy            |
+| Overall Wrong Response Rate  | 0%              | 0%              | 3%              | 3%              | Driven by semantic errors              |
+| Embedding Cost (ms)          | 0.00            | 0.00            | 262.35          | 114.72          | Semantic overhead                      |
+| Lookup Cost (ms)             | 0.00            | 12.23           | 29.61           | 17.11           | Cache search cost                      |
+| Latency Overhead (ms)        | 0.00            | 12.23           | 291.96          | 131.83          | —                                      |
+
+Note: All these runs were from COLD starts


### PR DESCRIPTION
# PR: Task #12 and #13 

## Notes
- This PR adds cache infrastructure, observability, and benchmark/test support.
- `/api/tag` JSON body remains unchanged: `{ parsed, emissions }`.
- New response headers expose cache behavior and timing.

## Summary
Implements a local persistent cache for OCR results with three modes:
1. `exact` (SHA-256 image hash)
2. `semantic` (similarity search over image embeddings)
3. `tiered` (exact first, semantic fallback)

Also adds `MOCK_OCR=1` support for keyless cache testing, plus benchmark tooling updates to compare hit rate, false positives, latency overhead, and memory.

## What Changed

### Cache Modules Added
- `backend/cache/config.js`
  - Centralized env parsing:
    - `CACHE_ENABLED`
    - `CACHE_DB_PATH`
    - `CACHE_SIMILARITY_THRESHOLD`
    - `CACHE_MAX_ENTRIES`
    - `CACHE_FINGERPRINT_VERSION`
    - `CACHE_MODE` (`exact|semantic|tiered`)
    - `CACHE_SEMANTIC_EMBEDDER` (`clip|fingerprint`)
    - `CACHE_SEMANTIC_CLIP_MODEL`
    - `CACHE_SEMANTIC_FALLBACK` (`none|fingerprint`)
    - `MOCK_OCR`

- `backend/cache/db.js`
  - SQLite persistence via `better-sqlite3`
  - `cache_entries` table with metadata and hit counters
  - pruning support and reset helpers

- `backend/cache/fingerprint.js`
  - SHA-256 image hash
  - deterministic image fingerprint vector
  - cosine similarity

- `backend/cache/embedding.js`
  - semantic embedding pipeline
  - CLIP (`@xenova/transformers`) support
  - optional fallback to local fingerprint embedder

- `backend/cache/service.js`
  - cache lookup/store orchestration
  - exact, semantic, and tiered lookup logic
  - max-entry pruning
  - test hooks

### API Updates
- `backend/api/tag.js`
  - Integrates lookup before OCR and write-through store on miss
  - Adds mock OCR path (`MOCK_OCR=1`) for deterministic keyless testing
  - Calculates semantic false positives in mock mode
  - Adds cache headers on every response:
    - `X-Cache-Status`
    - `X-Cache-Mode`
    - `X-Cache-Embedder`
    - `X-Cache-Similarity`
    - `X-Cache-Embedding-Ms`
    - `X-Cache-Lookup-Ms`
    - `X-Cache-False-Positive`
    - `X-Cache-RSS-MB`
  - Adds `POST /api/cache/reset` for benchmark cold-start runs

### AI / Mock Updates
- `backend/ai/mock.js`
  - Deterministic mock extractor based on image hash/fingerprint artifacts
  - Keeps parsed output stable for the same image

### Benchmark Updates
- `backend/benchmarks/vlm_benchmark.js`
  - Reads and reports cache headers per request
  - Computes:
    - `exact_hit_rate`
    - `semantic_hit_rate`
    - `overall_hit_rate`
    - `semantic_false_positive_rate`
    - `avg_embedding_ms`
    - `avg_lookup_ms`
    - `rss_mb_avg`, `rss_mb_max`
  - Automatically calls `POST /api/cache/reset` before each run
  - Writes JSON reports to `backend/benchmarks/results/<timestamp>.json`

### Tests Added/Updated
- `backend/test/e2e/tag.e2e.test.js`
  - cache miss in mock mode
  - exact-hit behavior
  - semantic-hit behavior
  - cache disabled behavior
  - contract remains `{ parsed, emissions }`

- `backend/test/unit/cache.service.test.js`
  - semantic threshold hit/miss behavior
  - prune behavior at max entries

- `backend/test/unit/fingerprint.test.js`
  - hash determinism
  - fingerprint determinism
  - cosine similarity sanity checks

### Docs / Repo Hygiene
- `README.md`
  - keyless cache test flow and mode-specific commands
- `docs/api.md`
  - cache env vars, reset endpoint, and response headers
- `.gitignore`
  - ignores benchmark result artifacts and local cache sqlite files

### Dependencies
- Added in `backend/package.json`:
  - `@xenova/transformers`
  - `better-sqlite3`
  - `jpeg-js`
  - `pngjs`

## How to Run

### 1) Install backend deps
```bash
cd backend
npm install
```

### 2) Start backend (keyless mock mode)
```bash
MOCK_OCR=1 CACHE_ENABLED=1 CACHE_MODE=tiered node server.js
```

### 3) Run benchmark
```bash
node benchmarks/vlm_benchmark.js \
  --url http://localhost:3001/api/tag \
  --images-dir ../cropped_tags \
  --runs 200 \
  --concurrency 4
```

### 4) Compare modes
```bash
# baseline
MOCK_OCR=1 CACHE_ENABLED=0 node server.js

# exact
MOCK_OCR=1 CACHE_ENABLED=1 CACHE_MODE=exact node server.js

# semantic
MOCK_OCR=1 CACHE_ENABLED=1 CACHE_MODE=semantic CACHE_SEMANTIC_EMBEDDER=clip node server.js

# tiered
MOCK_OCR=1 CACHE_ENABLED=1 CACHE_MODE=tiered CACHE_SEMANTIC_EMBEDDER=clip node server.js
```

## Validation
```bash
cd backend
npm test
```
