### PR TITLE
feat(gcp): Deploy to GCP Cloud Run

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+uploads/
+cache/*.sqlite

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-slim
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+ENV NODE_ENV=production
+ENV CACHE_ENABLED=false
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/backend/api/tag.js
+++ b/backend/api/tag.js
@@ -13,7 +13,7 @@ import { getCacheConfig, isMockOcrEnabled } from "../cache/config.js";
 import { countCacheEntries, lookup, resetCacheEntries, store } from "../cache/service.js";
 
 const router = express.Router();
-const upload = multer({ dest: "uploads/" });
+const upload = multer({ dest: "/tmp/uploads/" });
 let tagExtractor = gpt.extractTagFromImage;
 
 function isPlainObject(value) {


### PR DESCRIPTION
# feat(gcp): Deploy backend to GCP Cloud Run (#25)

## Summary

- Added `backend/Dockerfile` to containerize the Node.js Express backend for GCP Cloud Run
- Added `backend/.dockerignore` to exclude dev artifacts (`node_modules`, `.env`, `uploads/`, `cache/*.sqlite`) from the image
- Changed multer upload destination from `uploads/` to `/tmp/uploads/` so file writes land in Cloud Run's writable ephemeral filesystem


## Changes

| File | Change |
|------|--------|
| `backend/Dockerfile` | New — multi-stage-free slim Node 22 image; production deps only via `npm ci --omit=dev`; disables SQLite cache at runtime |
| `backend/.dockerignore` | New — prevents secrets, local DB, and temp uploads from being baked into the image |
| `backend/api/tag.js` | Updated multer `dest` from `uploads/` → `/tmp/uploads/` for Cloud Run compatibility |

## Deployment notes

- Image is built from `node:22-slim`, exposes port **8080** (Cloud Run default)
- `CACHE_ENABLED=false` is set at image build time; the SQLite cache is disabled in production since Cloud Run containers are stateless
- `OPENAI_API_KEY` must be injected as a **Secret Manager** secret or environment variable in the Cloud Run service — it is intentionally not in the image
- Multer writes uploads to `/tmp/uploads/`; Cloud Run provides a 512 MB in-memory `/tmp` filesystem per instance

## Hosted API URL
The backend is hosted on the following link: https://ecotag-backend-233238785463.us-central1.run.app/