### PR TITLE
Redesign results page and add scan storage foundation

### DIFF
--- a/mobile/app/loading.tsx
+++ b/mobile/app/loading.tsx
@@ -37,7 +37,7 @@ export default function LoadingScreen() {
 
       metrics.mark("uploadStart");
       try {
-        const response = await tagImage(imageUri);
+        const { response, scanId } = await tagImage(imageUri);
         metrics.mark("uploadEnd");
         metrics.logToConsole();
         router.replace({
@@ -45,6 +45,7 @@ export default function LoadingScreen() {
           params: {
             status: "success",
             data: JSON.stringify(response),
+            scanId,
           },
         });
       } catch (err) {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -26,7 +26,8 @@
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-safe-area-context": "~5.6.0",
-        "react-native-screens": "~4.16.0"
+        "react-native-screens": "~4.16.0",
+        "react-native-svg": "15.12.1"
       },
       "devDependencies": {
         "@types/react": "~19.1.10",
@@ -1569,30 +1570,6 @@
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-      "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@expo/config-plugins/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@expo/config-plugins/node_modules/glob": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
@@ -1611,15 +1588,15 @@
       }
     },
     "node_modules/@expo/config-plugins/node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1652,30 +1629,6 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "node_modules/@expo/config/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-      "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@expo/config/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@expo/config/node_modules/glob": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
@@ -1694,15 +1647,15 @@
       }
     },
     "node_modules/@expo/config/node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1795,30 +1748,6 @@
         "fingerprint": "bin/cli.js"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-      "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@expo/fingerprint/node_modules/glob": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
@@ -1837,15 +1766,15 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2082,15 +2011,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -3436,6 +3356,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -3458,12 +3384,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3889,6 +3827,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3995,6 +3983,61 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -4047,6 +4090,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -4780,30 +4835,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
-      "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/expo/node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/expo/node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -4847,15 +4878,15 @@
       }
     },
     "node_modules/expo/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5145,9 +5176,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5450,21 +5481,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-environment-node": {
@@ -6145,6 +6161,12 @@
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -6512,12 +6534,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.8.tgz",
+      "integrity": "sha512-reYkDYtj/b19TeqbNZCV4q9t+Yxylf/rYBsLb42SXJatTv4/ylq5lEiAmhA/IToxO7NI2UzNMghHoHuaqDkAjw==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6673,6 +6695,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -7370,6 +7404,21 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",
@@ -8184,9 +8233,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -8282,9 +8331,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -27,7 +27,8 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0"
+    "react-native-screens": "~4.16.0",
+    "react-native-svg": "15.12.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.10",

--- a/mobile/src/components/BreakdownRow.tsx
+++ b/mobile/src/components/BreakdownRow.tsx
@@ -1,57 +1,57 @@
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, Text, View } from "react-native";
 import { colors, typography, spacing } from "../theme";
 
 interface Props {
   label: string;
   kgValue: number;
-  onPress?: () => void;
 }
 
-export function BreakdownRow({ label, kgValue, onPress }: Props) {
+export function BreakdownRow({ label, kgValue }: Props) {
   return (
-    <Pressable style={styles.row} onPress={onPress}>
-      <View style={styles.left}>
-        <Text style={styles.label}>{label}</Text>
-        <Text style={styles.value}>{kgValue.toFixed(1)} kg</Text>
+    <View style={styles.card}>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.badge}>
+        <Text style={styles.badgeText}>{Math.round(kgValue)} kg</Text>
       </View>
-      <View style={styles.right}>
-        <Text style={styles.details}>VIEW DETAILS</Text>
-        <Ionicons name="chevron-forward" size={16} color={colors.disabled} />
-      </View>
-    </Pressable>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  row: {
+  card: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
+    backgroundColor: colors.background,
+    borderRadius: spacing.radius,
+    height: 60,
+    paddingHorizontal: 15,
     paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-  },
-  left: {
-    gap: 2,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 4,
   },
   label: {
-    ...typography.subtitle2,
+    ...typography.subtitle1,
     color: colors.text,
+    letterSpacing: 0.32,
   },
-  value: {
-    ...typography.bodySmall,
-    color: colors.disabled,
-  },
-  right: {
-    flexDirection: "row",
+  badge: {
+    backgroundColor: colors.primaryMid,
+    borderRadius: spacing.radius,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    minWidth: 70,
     alignItems: "center",
-    gap: spacing.iconTextGap,
   },
-  details: {
-    ...typography.bodySmall,
-    color: colors.disabled,
-    letterSpacing: 0.5,
+  badgeText: {
+    fontFamily: typography.h2.fontFamily,
+    fontSize: 20,
+    lineHeight: 25,
+    letterSpacing: 0.4,
+    color: colors.white,
   },
 });

--- a/mobile/src/components/CO2Gauge.tsx
+++ b/mobile/src/components/CO2Gauge.tsx
@@ -1,59 +1,65 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { colors, typography, spacing } from "../theme";
+import Svg, { Path } from "react-native-svg";
+import { colors, typography } from "../theme";
+
+function TreeIcon() {
+  return (
+    <Svg width={107} height={107} viewBox="0 0 107 107" fill="none">
+      <Path
+        d="M53.5 82.0947C54.7255 82.9107 56.0019 83.6476 57.3214 84.301V103.179C57.3214 104.193 56.9188 105.164 56.2021 105.881C55.4855 106.597 54.5135 107 53.5 107C52.4865 107 51.5145 106.597 50.7978 105.881C50.0812 105.164 49.6786 104.193 49.6786 103.179V84.301C50.998 83.6476 52.2744 82.9107 53.5 82.0947ZM86.9852 22.2741C84.2208 15.6752 79.5674 10.0403 73.6098 6.07731C67.6521 2.11432 60.6558 0 53.5 0C46.3441 0 39.3479 2.11432 33.3902 6.07731C27.4325 10.0403 22.7792 15.6752 20.0148 22.2741C14.0448 25.0022 8.98456 29.3877 5.43626 34.9088C1.88796 40.4298 0.00105448 46.8539 0.000111307 53.4165C-0.0476564 71.6597 15.2858 87.4196 33.5044 87.8972C39.1079 88.0299 44.6594 86.7956 49.6786 84.301V67.3329L28.8614 56.9314C27.9543 56.478 27.2645 55.6829 26.9438 54.721C26.6231 53.7591 26.6978 52.7092 27.1513 51.8023C27.6048 50.8954 28.4001 50.2058 29.3623 49.8852C30.3244 49.5646 31.3745 49.6392 32.2816 50.0926L49.6786 58.794V34.4092C49.6786 33.3959 50.0812 32.4241 50.7978 31.7076C51.5145 30.9911 52.4865 30.5886 53.5 30.5886C54.5135 30.5886 55.4855 30.9911 56.2021 31.7076C56.9188 32.4241 57.3214 33.3959 57.3214 34.4092V47.3322L74.7184 38.6309C75.1676 38.4064 75.6565 38.2725 76.1574 38.2369C76.6583 38.2013 77.1613 38.2647 77.6377 38.4235C78.1141 38.5822 78.5545 38.8333 78.9339 39.1622C79.3133 39.4911 79.6241 39.8916 79.8487 40.3406C80.0732 40.7896 80.2072 41.2785 80.2428 41.7793C80.2783 42.2801 80.2149 42.783 80.0561 43.2592C79.8973 43.7355 79.6463 44.1759 79.3173 44.5552C78.9882 44.9344 78.5877 45.2452 78.1386 45.4697L57.3214 55.8712V84.301C62.0721 86.6594 67.303 87.8901 72.6071 87.8972H73.4765C91.7142 87.4196 107.052 71.6597 107 53.4165C106.999 46.8539 105.112 40.4298 101.564 34.9088C98.0154 29.3877 92.9552 25.0022 86.9852 22.2741Z"
+        fill={colors.primary}
+      />
+    </Svg>
+  );
+}
 
 interface Props {
   totalKgCO2e: number;
 }
 
 export function CO2Gauge({ totalKgCO2e }: Props) {
+  const display =
+    totalKgCO2e >= 1
+      ? `${Math.round(totalKgCO2e)} kg `
+      : `${(totalKgCO2e * 1000).toFixed(0)} g `;
+
   return (
     <View style={styles.container}>
-      {/* Semi-circle gauge placeholder */}
-      <View style={styles.gauge}>
-        <View style={styles.semicircle} />
-        <Text style={styles.value}>{totalKgCO2e.toFixed(1)}</Text>
-        <Text style={styles.unit}>kg</Text>
+      <View style={styles.textColumn}>
+        <Text style={styles.value}>{display}</Text>
+        <Text style={styles.label}>Carbon Dioxide Equivalent</Text>
       </View>
-      <Text style={styles.label}>Carbon Dioxide Equivalent</Text>
+      <TreeIcon />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flexDirection: "row",
     alignItems: "center",
-    gap: spacing.iconTextGap,
+    justifyContent: "space-between",
   },
-  gauge: {
-    width: 200,
-    height: 120,
+  textColumn: {
+    width: 193,
     alignItems: "center",
-    justifyContent: "flex-end",
-  },
-  semicircle: {
-    position: "absolute",
-    top: 0,
-    width: 200,
-    height: 100,
-    borderTopLeftRadius: 100,
-    borderTopRightRadius: 100,
-    borderWidth: 8,
-    borderBottomWidth: 0,
-    borderColor: colors.primaryMid,
+    justifyContent: "center",
+    gap: 5,
   },
   value: {
-    ...typography.h1,
+    fontFamily: typography.h1.fontFamily,
+    fontSize: 48,
+    lineHeight: 60,
+    letterSpacing: 0.96,
     color: colors.text,
-    fontSize: 32,
-  },
-  unit: {
-    ...typography.bodySmall,
-    color: colors.disabled,
+    textAlign: "center",
   },
   label: {
-    ...typography.subtitle2,
-    color: colors.disabled,
-    marginTop: 4,
+    ...typography.body,
+    color: colors.text,
+    letterSpacing: 0.28,
+    width: 172,
+    textAlign: "center",
   },
 });

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -3,6 +3,11 @@ import { addScan } from "../storage/scans";
 import { lookupCache, storeCache } from "../storage/imageCache";
 import { ParsedTag, TagApiResponse } from "../types/api";
 
+export interface TagImageResult {
+  response: TagApiResponse;
+  scanId: string;
+}
+
 export interface NormalizedApiError {
   status: number;
   code?: string;
@@ -89,10 +94,11 @@ function recordScan(params: {
   category: string | null;
   error_code: string | null;
   result: unknown;
-}): void {
+}): string {
+  const id = makeScanId();
   try {
     addScan({
-      id: makeScanId(),
+      id,
       created_at: Date.now(),
       success: params.success,
       co2e_grams: params.co2e_grams,
@@ -104,6 +110,7 @@ function recordScan(params: {
   } catch (err) {
     console.warn("[EcoTag] Failed to write scan history:", err);
   }
+  return id;
 }
 
 function normalizeErrorPayload(
@@ -130,10 +137,10 @@ function normalizeErrorPayload(
   };
 }
 
-export async function tagImage(imageUri: string): Promise<TagApiResponse> {
+export async function tagImage(imageUri: string): Promise<TagImageResult> {
   const cached = await lookupCache(imageUri);
   if (cached) {
-    recordScan({
+    const scanId = recordScan({
       success: 1,
       co2e_grams: Math.round(cached.emissions.total_kgco2e * 1000),
       display_name: buildDisplayName(cached.parsed),
@@ -141,7 +148,7 @@ export async function tagImage(imageUri: string): Promise<TagApiResponse> {
       error_code: null,
       result: { parsed: cached.parsed, emissions: cached.emissions },
     });
-    return cached;
+    return { response: cached, scanId };
   }
 
   const formData = new FormData();
@@ -216,7 +223,7 @@ export async function tagImage(imageUri: string): Promise<TagApiResponse> {
 
   const response = parsed as TagApiResponse;
   await storeCache(imageUri, response);
-  recordScan({
+  const scanId = recordScan({
     success: 1,
     co2e_grams: Math.round(response.emissions.total_kgco2e * 1000),
     display_name: buildDisplayName(response.parsed),
@@ -225,5 +232,5 @@ export async function tagImage(imageUri: string): Promise<TagApiResponse> {
     result: { parsed: response.parsed, emissions: response.emissions },
   });
 
-  return response;
+  return { response, scanId };
 }

--- a/mobile/src/storage/db.ts
+++ b/mobile/src/storage/db.ts
@@ -1,7 +1,7 @@
 import { SQLiteDatabase, openDatabaseSync } from "expo-sqlite";
 
 const DB_NAME = "ecotag.db";
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 
 let db: SQLiteDatabase | null = null;
 
@@ -45,6 +45,13 @@ export function initDb(): void {
         response_json TEXT NOT NULL,
         created_at INTEGER NOT NULL
       );
+    `);
+  }
+
+  if (currentVersion < 3) {
+    database.execSync(`
+      ALTER TABLE scans ADD COLUMN in_closet INTEGER NOT NULL DEFAULT 0;
+      CREATE INDEX IF NOT EXISTS idx_scans_in_closet ON scans(in_closet);
     `);
   }
 

--- a/mobile/src/storage/types.ts
+++ b/mobile/src/storage/types.ts
@@ -7,6 +7,7 @@ export interface ScanRecord {
   category: string | null;
   error_code: string | null;
   result_json: string | null;
+  in_closet: 0 | 1;
 }
 
 export interface NewScanRecord {


### PR DESCRIPTION
## Summary

Redesign the results page to match the prototype with an X button, hanger/closet toggle, and breakdown only view. Also adds the storage layer foundation (in_closet column, scanId tracking) needed by the closet feature.

## PR Size

Small

---

## Context / Motivation

#36: Results from Scan: mirror the results page with the prototype, add X button to go back to scan, add hanger button to save to closet, and remove the tag details card to show only the breakdown.

## Changes

- Redesign results page header: back arrow -> X button, bookmark -> hanger/closet toggle with plus badge
- Remove tag details card, show only carbon emission breakdown
- Update CO2Gauge and BreakdownRow components to match prototype styling
- Change `tagImage` API to return `{ response, scanId }` for scan tracking
- Add `in_closet` column to scans table (schema v3) with closet storage functions
- Add `react-native-svg` dependency

## How to Test

1. Scan a garment and verify the results page matches the prototype
2. Verify the X button in the top-left navigates back to the scan page
3. Tap the hanger button and verify it toggles the closet state (icon color changes)
4. Verify "Scan Another" button prompts a new scan
5. Verify the breakdown rows display correctly without the old tag details card

---