### PR TITLE
docs: add setup guide and .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,19 @@
+# ── OpenAI ────────────────────────────────────────────────────────
+# Required. Get your key at https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-proj-your-key-here
+
+# ── Server ────────────────────────────────────────────────────────
+# PORT=3001                      # default: 3001
+
+# ── Mock mode (skip OpenAI calls) ─────────────────────────────────
+# MOCK_OCR=false                 # set to "1" or "true" to use mock tag extraction
+
+# ── Cache ─────────────────────────────────────────────────────────
+# CACHE_ENABLED=true
+# CACHE_DB_PATH=./cache/ecotag-cache.sqlite
+# CACHE_MODE=tiered              # exact | semantic | tiered
+# CACHE_SIMILARITY_THRESHOLD=0.9
+# CACHE_MAX_ENTRIES=5000
+# CACHE_SEMANTIC_EMBEDDER=clip   # clip | fingerprint
+# CACHE_SEMANTIC_CLIP_MODEL=Xenova/clip-vit-base-patch32
+# CACHE_SEMANTIC_FALLBACK=none   # none | fingerprint


### PR DESCRIPTION
## Summary
Rewrite README with SETUP instructions  for running the mobile app (iOS Simulator via Xcode or real iPhone via Expo Go)

## Details
Covers Node.js installation, OpenAI API key setup, backend configuration, and two options for running the mobile app (iOS Simulator via Xcode or real iPhone via Expo Go). Also added backend/.env.example with all available environment variables documented.