### PR TITLE
Add Cloud Build config for Cloud Run auto-deploy

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,34 @@
+steps:
+  # 1. Build Docker image from backend/Dockerfile
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -t
+      - us-east1-docker.pkg.dev/b2-ecotag/cloud-run-source-deploy/ecotag-app-service:$COMMIT_SHA
+      - -f
+      - backend/Dockerfile
+      - backend
+
+  # 2. Push image to Artifact Registry
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - us-east1-docker.pkg.dev/b2-ecotag/cloud-run-source-deploy/ecotag-app-service:$COMMIT_SHA
+
+  # 3. Deploy pushed image to Cloud Run
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - ecotag-app-service
+      - --image
+      - us-east1-docker.pkg.dev/b2-ecotag/cloud-run-source-deploy/ecotag-app-service:$COMMIT_SHA
+      - --region
+      - us-east1
+      - --platform
+      - managed
+      - --quiet
+
+images:
+  - us-east1-docker.pkg.dev/b2-ecotag/cloud-run-source-deploy/ecotag-app-service:$COMMIT_SHA


### PR DESCRIPTION
## Summary

Adds a `cloudbuild.yaml` file that builds the backend Docker image, pushes it to Artifact Registry, and deploys the image to Cloud Run.

## Why

The current Cloud Build trigger successfully builds/pushes the Docker image, but it does not automatically create a new Cloud Run revision. This caused Cloud Run to continue serving an older revision even after a successful build (e.g. build `a8c0354` succeeded but Cloud Run kept serving an 11-day-old revision until a manual deploy created `ecotag-app-service-00006-s6h`).

## What this changes

The new Cloud Build config explicitly performs:

1. Docker build from `backend/Dockerfile` (context: `backend`), tagged `$COMMIT_SHA`
2. Docker push to `us-east1-docker.pkg.dev/b2-ecotag/cloud-run-source-deploy/ecotag-app-service`
3. `gcloud run deploy` to `ecotag-app-service` in `us-east1`

## Required follow-up (in GCP Console, after merge)

1. Cloud Build -> Triggers -> open the trigger for `benevolentbandwidth/ecotag` -> change configuration from **Dockerfile** to **Cloud Build configuration file**, path `/cloudbuild.yaml`.
2. Verify the Cloud Build service account has these roles: `Cloud Run Admin`, `Service Account User`, `Artifact Registry Writer`, `Logs Writer`.

## Test plan

- [ ] Merge this PR
- [ ] Update the Cloud Build trigger to use `/cloudbuild.yaml`
- [ ] Make a small test commit to `main`
- [ ] Confirm a new Cloud Build starts automatically
- [ ] Confirm the build log includes the `gcloud run deploy ecotag-app-service` step
- [ ] Confirm a new Cloud Run revision is created and serves 100% traffic

## Rollback

Revert this commit, or in GCP switch the trigger back to Dockerfile mode. Traffic can be rerouted to prior revision `ecotag-app-service-00006-s6h`.

Generated with [Claude Code](https://claude.com/claude-code)