### PR TITLE
Set Cloud Build logging to CLOUD_LOGGING_ONLY

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,3 +32,6 @@ steps:
 
 images:
   - us-east1-docker.pkg.dev/b2-ecotag/cloud-run-source-deploy/ecotag-app-service:$COMMIT_SHA
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## Summary

Adds `options.logging: CLOUD_LOGGING_ONLY` to `cloudbuild.yaml`.

## Why

Follow-up to #73. Cloud Build requires an explicit logging destination when no logs bucket is configured; without it the build can fail with a logging configuration error. `CLOUD_LOGGING_ONLY` sends logs to Cloud Logging only, no GCS bucket needed.

## What this changes

```yaml
options:
  logging: CLOUD_LOGGING_ONLY
```

Appended to existing `cloudbuild.yaml`. No other changes.

## Test plan

- [ ] Merge this PR
- [ ] Trigger a build on `main`
- [ ] Confirm build completes without logging configuration errors
- [ ] Confirm build logs visible in Cloud Logging

Generated with [Claude Code](https://claude.com/claude-code)