### PR TITLE
Add ground-truth evaluation workflow and scoring script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ backend/cache/test-tag-e2e.sqlite
 backend/uploads/
 
 CLAUDE.md
+read.txt

--- a/cropped_tags/IMG_8583.JPG.json.gt
+++ b/cropped_tags/IMG_8583.JPG.json.gt
@@ -1,0 +1,11 @@
+{
+  "ocr_text": "Made in China. Hand wash cold. Do not bleach. Reshape while damp. Dry flat. Cool iron only if needed. Dry clean. French hand-wash text repeats care instructions.",
+  "country": "China",
+  "materials": [],
+  "care": {
+    "washing": "hand_wash_cold",
+    "drying": "lay_flat_to_dry",
+    "ironing": "iron_low",
+    "dry_cleaning": "dry_clean"
+  }
+}

--- a/cropped_tags/IMG_8588.JPG.json.gt
+++ b/cropped_tags/IMG_8588.JPG.json.gt
@@ -1,0 +1,24 @@
+{
+  "ocr_text": "Made in Peru. 52% modal, 24% polyester, 24% cotton. Machine wash cold with like colors. Only non-chlorine bleach when needed. Tumble dry low. Iron on lowest setting.",
+  "country": "Peru",
+  "materials": [
+    {
+      "fiber": "Modal",
+      "pct": 52
+    },
+    {
+      "fiber": "Polyester",
+      "pct": 24
+    },
+    {
+      "fiber": "Cotton",
+      "pct": 24
+    }
+  ],
+  "care": {
+    "washing": "machine_wash_cold",
+    "drying": "tumble_dry_low",
+    "ironing": "iron_low",
+    "dry_cleaning": null
+  }
+}

--- a/cropped_tags/IMG_8590.JPG.json.gt
+++ b/cropped_tags/IMG_8590.JPG.json.gt
@@ -1,0 +1,28 @@
+{
+  "ocr_text": "Made in Cambodia. Body 80% cotton, 20% polyester. Trim 98% cotton, 2% spandex. Trimming and decoration excluded. Care instructions are not visible in this crop.",
+  "country": "Cambodia",
+  "materials": [
+    {
+      "fiber": "Cotton",
+      "pct": 80
+    },
+    {
+      "fiber": "Polyester",
+      "pct": 20
+    },
+    {
+      "fiber": "Cotton",
+      "pct": 98
+    },
+    {
+      "fiber": "Spandex",
+      "pct": 2
+    }
+  ],
+  "care": {
+    "washing": null,
+    "drying": null,
+    "ironing": null,
+    "dry_cleaning": null
+  }
+}

--- a/cropped_tags/IMG_8591.JPG.json.gt
+++ b/cropped_tags/IMG_8591.JPG.json.gt
@@ -1,0 +1,24 @@
+{
+  "ocr_text": "Made in Philippines. 65% polyester, 33% viscose, 2% elastane. Machine wash cold with like colors. Non-chlorine bleach only. Tumble dry low. Iron on lowest setting.",
+  "country": "Philippines",
+  "materials": [
+    {
+      "fiber": "Polyester",
+      "pct": 65
+    },
+    {
+      "fiber": "Viscose",
+      "pct": 33
+    },
+    {
+      "fiber": "Elastane",
+      "pct": 2
+    }
+  ],
+  "care": {
+    "washing": "machine_wash_cold",
+    "drying": "tumble_dry_low",
+    "ironing": "iron_low",
+    "dry_cleaning": null
+  }
+}

--- a/cropped_tags/IMG_8592.JPG.json.gt
+++ b/cropped_tags/IMG_8592.JPG.json.gt
@@ -1,0 +1,16 @@
+{
+  "ocr_text": "Made in Vietnam. US/GB: 100% merino extra fine wool. Machine wash cold gentle cycle. Close fasteners. Wash in mesh bag. Use mild detergent. Wash separately. Non-chlorine bleach when needed. Reshape and dry flat. Cool iron. Professional clean P symbol.",
+  "country": "Vietnam",
+  "materials": [
+    {
+      "fiber": "Merino",
+      "pct": 100
+    }
+  ],
+  "care": {
+    "washing": "machine_wash_gentle",
+    "drying": "lay_flat_to_dry",
+    "ironing": "iron_low",
+    "dry_cleaning": "dry_clean"
+  }
+}

--- a/cropped_tags/IMG_8596.JPG.json.gt
+++ b/cropped_tags/IMG_8596.JPG.json.gt
@@ -1,0 +1,24 @@
+{
+  "ocr_text": "Made in China. 52% viscose, 36% nylon, 12% polyester. Machine wash cold with like colors. Only non-chlorine bleach when needed. Tumble dry low. Warm iron if necessary.",
+  "country": "China",
+  "materials": [
+    {
+      "fiber": "Viscose",
+      "pct": 52
+    },
+    {
+      "fiber": "Nylon",
+      "pct": 36
+    },
+    {
+      "fiber": "Polyester",
+      "pct": 12
+    }
+  ],
+  "care": {
+    "washing": "machine_wash_cold",
+    "drying": "tumble_dry_low",
+    "ironing": "iron_medium",
+    "dry_cleaning": null
+  }
+}

--- a/cropped_tags/IMG_8599.JPG.json.gt
+++ b/cropped_tags/IMG_8599.JPG.json.gt
@@ -1,0 +1,16 @@
+{
+  "ocr_text": "100% cashmere. Dry clean or hand wash cold. Do not twist or wring. Do not bleach. Reshape and lay flat to dry.",
+  "country": null,
+  "materials": [
+    {
+      "fiber": "Cashmere",
+      "pct": 100
+    }
+  ],
+  "care": {
+    "washing": "hand_wash_cold",
+    "drying": "lay_flat_to_dry",
+    "ironing": null,
+    "dry_cleaning": "dry_clean"
+  }
+}

--- a/cropped_tags/IMG_8600.JPG.json.gt
+++ b/cropped_tags/IMG_8600.JPG.json.gt
@@ -1,0 +1,16 @@
+{
+  "ocr_text": "Made in Vietnam. 100% cotton. Dry clean. Partial care text is visible below.",
+  "country": "Vietnam",
+  "materials": [
+    {
+      "fiber": "Cotton",
+      "pct": 100
+    }
+  ],
+  "care": {
+    "washing": null,
+    "drying": null,
+    "ironing": null,
+    "dry_cleaning": "dry_clean"
+  }
+}

--- a/cropped_tags/IMG_8601.JPG.json.gt
+++ b/cropped_tags/IMG_8601.JPG.json.gt
@@ -1,0 +1,16 @@
+{
+  "ocr_text": "100% cashmere. Dry clean or hand wash cold. Do not twist or wring. Do not bleach. Reshape and lay flat to dry. Warm iron if needed.",
+  "country": null,
+  "materials": [
+    {
+      "fiber": "Cashmere",
+      "pct": 100
+    }
+  ],
+  "care": {
+    "washing": "hand_wash_cold",
+    "drying": "lay_flat_to_dry",
+    "ironing": "iron_medium",
+    "dry_cleaning": "dry_clean"
+  }
+}

--- a/cropped_tags/IMG_8602.JPG.json.gt
+++ b/cropped_tags/IMG_8602.JPG.json.gt
@@ -1,0 +1,24 @@
+{
+  "ocr_text": "49% rayon, 31% polyester, 20% nylon. Origin and care instructions are not visible in this crop.",
+  "country": null,
+  "materials": [
+    {
+      "fiber": "Rayon",
+      "pct": 49
+    },
+    {
+      "fiber": "Polyester",
+      "pct": 31
+    },
+    {
+      "fiber": "Nylon",
+      "pct": 20
+    }
+  ],
+  "care": {
+    "washing": null,
+    "drying": null,
+    "ironing": null,
+    "dry_cleaning": null
+  }
+}

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,75 @@
+# Evaluation
+
+EcoTag evaluation uses manually labeled ground truth files and a scorer that compares those labels with system output.
+
+## Ground Truth Format
+
+Ground truth files live beside their source image and use the source image name plus `.json.gt`.
+
+```text
+cropped_tags/IMG_8592.JPG
+cropped_tags/IMG_8592.JPG.json.gt
+```
+
+Each ground truth file uses the parsed tag shape returned by the backend. `ocr_text` is kept for traceability, but the scorer ignores OCR text.
+
+```json
+{
+  "ocr_text": "Made in Vietnam. 100% cotton.",
+  "country": "Vietnam",
+  "materials": [
+    { "fiber": "Cotton", "pct": 100 }
+  ],
+  "care": {
+    "washing": "machine_wash_cold",
+    "drying": "line_dry",
+    "ironing": "iron_low",
+    "dry_cleaning": null
+  }
+}
+```
+
+Missing fields should be explicit: use `null` for missing scalar fields and `[]` for no visible materials.
+
+## Generating Predictions
+
+Start the backend, then capture predictions from the current system.
+
+```bash
+python scripts/tag.py "cropped_tags/*.JPG" --json > predictions.json
+```
+
+Progress output goes to stderr when `--json` is used, so `predictions.json` remains valid JSON.
+
+## Scoring
+
+Score a batch prediction file against all available `.json.gt` files:
+
+```bash
+python scripts/score_ground_truth.py --ground-truth-dir cropped_tags --predictions-file predictions.json
+```
+
+Score a directory of per-image prediction files. By default, the scorer expects files like `IMG_8592.JPG.json`:
+
+```bash
+python scripts/score_ground_truth.py --ground-truth-dir cropped_tags --predictions-dir predictions
+```
+
+Self-check the ground truth files. This should produce perfect scores and is useful after editing labels:
+
+```bash
+python scripts/score_ground_truth.py --ground-truth-dir cropped_tags --predictions-dir cropped_tags --prediction-suffix .json.gt
+```
+
+The scorer reports per-field precision, recall, and F1 for:
+
+- `country`
+- `materials`
+- `care.washing`
+- `care.drying`
+- `care.ironing`
+- `care.dry_cleaning`
+
+`NO_TAG_DETECTED` and other error responses are treated as empty parsed output. If the ground truth has visible fields, those become false negatives.
+
+Use `--pct-tolerance N` to allow material percentages to differ by `N` percentage points. Use `--check-sklearn` to compare scalar-field scoring with scikit-learn if it is installed.

--- a/docs/ground-truth-label-notes.md
+++ b/docs/ground-truth-label-notes.md
@@ -1,0 +1,87 @@
+# Ground Truth Label Notes
+
+Manual review of a small sample from `cropped_tags/`, based on the workflow in `read.txt`.
+
+## Image Notes
+
+- `cropped_tags/IMG_8592.JPG`
+  - Origin: Made in Vietnam.
+  - Materials: `US/GB: 100% Merino extra fine wool`.
+  - Care: has both symbols and text. Visible symbols include wash 30, bleach triangle, do-not-tumble-dry style crossed square, low/one-dot iron, dry flat, and professional clean `P`.
+  - Text care says machine wash cold gentle cycle, close fasteners, wash in mesh bag, use mild detergent, wash separately, non-chlorine bleach when needed, reshape and dry flat, cool iron.
+  - Important edge case: material line has locale prefix `US/GB`; care has duplicated symbol + text information.
+
+- `cropped_tags/IMG_8583.JPG`
+  - Origin: Made in China.
+  - Materials: no composition visible in this crop.
+  - Care: hand wash cold; do not bleach; reshape while damp; dry flat; cool iron only if needed; dry clean; laver a la main text repeats in French.
+  - Important edge case: multilingual care text and missing/hidden material composition.
+
+- `cropped_tags/IMG_8591.JPG`
+  - Origin: Made in Philippines, repeated in several languages.
+  - Materials: visible composition includes 65% polyester, 33% viscose, 2% elastane.
+  - Care: machine wash cold with like colors, non-chlorine bleach only, tumble dry low, iron on lowest setting.
+  - Important edge case: same origin appears in many languages; material names are repeated in multiple languages.
+
+- `cropped_tags/IMG_8590.JPG`
+  - Origin: Made in Cambodia.
+  - Materials: body is 80% cotton / 20% polyester; trim is 98% cotton / 2% spandex. Trimming and decoration excluded.
+  - Care: not visible in this crop.
+  - Important edge case: multiple garment parts need separate material compositions.
+
+- `cropped_tags/IMG_8588.JPG`
+  - Origin: Made in Peru.
+  - Materials: visible composition includes 52% modal, 24% polyester, 24% cotton.
+  - Care: machine wash cold with like colors, non-chlorine bleach only, tumble dry low, iron on lowest setting.
+  - Important edge case: multilingual origin and material names; image partly cut off on the right.
+
+- `cropped_tags/IMG_8602.JPG`
+  - Origin: not visible in this crop.
+  - Materials: 49% rayon, 31% polyester, 20% nylon.
+  - Care: not visible.
+  - Important edge case: material-only crop.
+
+- `cropped_tags/IMG_8601.JPG`
+  - Origin: not visible in this crop.
+  - Materials: 100% cashmere.
+  - Care: visible care says dry clean or hand wash cold, do not twist or wring, do not bleach, reshape and lay flat to dry, warm iron if needed.
+  - Important edge case: partial crop with premium fiber and multiple care prohibitions.
+
+- `cropped_tags/IMG_8600.JPG`
+  - Origin: Made in Vietnam.
+  - Materials: 100% cotton.
+  - Care: visible care includes dry clean, made in Vietnam, and partial care text below.
+  - Important edge case: likely adjacent/overlapping crop from the same physical tag as another image; labels may need grouping by garment or tag side, not just image.
+
+- `cropped_tags/IMG_8599.JPG`
+  - Origin: not visible in this crop.
+  - Materials: 100% cashmere.
+  - Care: dry clean or hand wash cold, do not twist/wring, do not bleach, reshape and lay flat to dry.
+  - Important edge case: duplicate or near-duplicate of another cashmere crop, useful for checking model consistency across similar crops.
+
+- `cropped_tags/IMG_8596.JPG`
+  - Origin: Made in China.
+  - Materials: visible composition includes 52% viscose, 36% nylon, 12% polyester.
+  - Care: machine wash cold with like colors, only non-chlorine bleach when needed, tumble dry low, warm iron if necessary.
+  - Important edge case: material composition and care share one crop, but the top line is cut off, so partial OCR should not be treated as a full label.
+
+## Schema Fields That Look Necessary
+
+- `source_image`: file name or image id.
+- `origin_country`: normalized country, plus optional raw text.
+- `materials`: list of garment parts. Each part should have `part_name`, `fibers`, and `raw_text`.
+- `fibers`: list of `{ fiber, percent }`, because a single garment can contain several blends.
+- `exclusions`: text like "exclusive of trimming and decoration".
+- `care`: structured fields for washing, drying, ironing, bleaching, dry cleaning, and extra instructions.
+- `care_symbols`: list of detected visual symbols with normalized meaning and optional confidence.
+- `languages`: languages observed on the tag.
+- `raw_text`: OCR transcription for traceability.
+- `crop_quality_notes`: blur, cutoff text, missing fields, duplicated languages, symbol-only fields.
+- `related_images`: optional list of images that appear to be adjacent crops or duplicates from the same garment/tag.
+
+## Early Takeaways
+
+- Ground truth should preserve both normalized values and raw text. The normalized values are needed for scoring, while raw text helps debug model mistakes.
+- Materials need garment-part support, not just one flat material list.
+- Care should support both symbol-derived and text-derived evidence.
+- Missing fields should be explicit. Several crops show only materials or only care/origin.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -78,6 +78,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2691,6 +2692,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
       "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.14.0",
         "escape-string-regexp": "^4.0.0",
@@ -2844,6 +2846,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3435,6 +3438,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4191,6 +4195,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -4278,6 +4283,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -4314,6 +4320,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -4349,6 +4356,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -7268,6 +7276,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7287,6 +7296,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7323,6 +7333,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -7390,6 +7401,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -7400,6 +7412,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -7492,6 +7505,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8407,6 +8421,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,3 +38,22 @@ python scripts/tag.py tag.jpg --url http://staging:3001/api/tag
 ```
 
 Default output per image shows country, materials, care instructions, CO₂e, and cache status. Exit code is non-zero if any image failed.
+
+---
+
+## score_ground_truth.py
+
+Compares `.json.gt` ground truth files with system predictions and reports per-field precision, recall, and F1.
+
+```bash
+# score a batch JSON file from tag.py
+python scripts/score_ground_truth.py --ground-truth-dir cropped_tags --predictions-file predictions.json
+
+# score per-image prediction files named like IMG_8592.JPG.json
+python scripts/score_ground_truth.py --ground-truth-dir cropped_tags --predictions-dir predictions
+
+# self-check ground truth labels after editing
+python scripts/score_ground_truth.py --ground-truth-dir cropped_tags --predictions-dir cropped_tags --prediction-suffix .json.gt
+```
+
+The scorer ignores `ocr_text` and scores `country`, `materials`, and each structured care field. See `docs/evaluation.md` for the full workflow.

--- a/scripts/score_ground_truth.py
+++ b/scripts/score_ground_truth.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Score EcoTag parsed tag output against .json.gt ground truth files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CARE_FIELDS = ("washing", "drying", "ironing", "dry_cleaning")
+SCORED_FIELDS = ("country", "materials", *tuple(f"care.{field}" for field in CARE_FIELDS))
+MISSING_LABEL = "__missing__"
+
+
+@dataclass
+class Counts:
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+
+    def add(self, other: "Counts") -> None:
+        self.tp += other.tp
+        self.fp += other.fp
+        self.fn += other.fn
+
+    @property
+    def precision(self) -> float:
+        denom = self.tp + self.fp
+        return self.tp / denom if denom else 0.0
+
+    @property
+    def recall(self) -> float:
+        denom = self.tp + self.fn
+        return self.tp / denom if denom else 0.0
+
+    @property
+    def f1(self) -> float:
+        denom = self.precision + self.recall
+        return (2 * self.precision * self.recall / denom) if denom else 0.0
+
+    @property
+    def support(self) -> int:
+        return self.tp + self.fn
+
+    def as_dict(self) -> dict[str, int | float]:
+        return {
+            "tp": self.tp,
+            "fp": self.fp,
+            "fn": self.fn,
+            "support": self.support,
+            "precision": round(self.precision, 4),
+            "recall": round(self.recall, 4),
+            "f1": round(self.f1, 4),
+        }
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{path}: invalid JSON: {exc}") from exc
+
+
+def empty_parsed() -> dict[str, Any]:
+    return {
+        "ocr_text": "",
+        "country": None,
+        "materials": [],
+        "care": {field: None for field in CARE_FIELDS},
+    }
+
+
+def extract_parsed(payload: Any) -> dict[str, Any]:
+    """Accept direct parsed JSON, API responses, tag.py rows, and error bodies."""
+    if not isinstance(payload, dict):
+        return empty_parsed()
+
+    if "result" in payload:
+        return extract_parsed(payload["result"])
+
+    if "parsed" in payload:
+        parsed = payload["parsed"]
+        return parsed if isinstance(parsed, dict) else empty_parsed()
+
+    if "error" in payload:
+        return empty_parsed()
+
+    if any(key in payload for key in ("country", "materials", "care", "ocr_text")):
+        return payload
+
+    return empty_parsed()
+
+
+def normalize_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if text in {"null", "none", "unknown", "n/a", "na", "-", "--"}:
+        return None
+    text = text.replace("_", " ")
+    text = re.sub(r"[^\w\s./-]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
+
+
+COUNTRY_ALIASES = {
+    "prc": "china",
+    "p.r.c": "china",
+    "usa": "united states",
+    "u.s.a": "united states",
+    "viet nam": "vietnam",
+}
+
+
+def normalize_country(value: Any) -> str | None:
+    text = normalize_text(value)
+    if text is None:
+        return None
+
+    for prefix in (
+        "made in ",
+        "manufactured in ",
+        "product of ",
+        "hecho en ",
+        "fabrique en ",
+        "fabricado en ",
+        "hergestellt in ",
+    ):
+        if text.startswith(prefix):
+            text = text[len(prefix) :].strip()
+            break
+
+    return COUNTRY_ALIASES.get(text, text)
+
+
+def normalize_pct(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value) if math.isfinite(float(value)) else None
+
+    match = re.search(r"-?\d+(?:\.\d+)?", str(value))
+    if not match:
+        return None
+    pct = float(match.group(0))
+    return pct if math.isfinite(pct) else None
+
+
+def normalize_fiber(value: Any) -> str | None:
+    text = normalize_text(value)
+    if text is None:
+        return None
+
+    text = re.sub(r"\b(us|gb|body|shell|trim|trimming|lining|exclusive|of)\b", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+
+    fiber_aliases = (
+        ("merino", "merino"),
+        ("cashmere", "cashmere"),
+        ("organic cotton", "organic cotton"),
+        ("pima cotton", "pima cotton"),
+        ("cotton", "cotton"),
+        ("coton", "cotton"),
+        ("algodon", "cotton"),
+        ("polyester", "polyester"),
+        ("polyamide", "nylon"),
+        ("nylon", "nylon"),
+        ("viscose", "viscose"),
+        ("rayon", "rayon"),
+        ("modal", "modal"),
+        ("lyocell", "lyocell"),
+        ("tencel", "tencel"),
+        ("elastane", "elastane"),
+        ("elasthane", "elastane"),
+        ("spandex", "elastane"),
+        ("wool", "wool"),
+        ("silk", "silk"),
+        ("linen", "linen"),
+        ("acrylic", "acrylic"),
+    )
+    for needle, canonical in fiber_aliases:
+        if needle in text:
+            return canonical
+    return text
+
+
+def normalize_care(value: Any) -> str | None:
+    text = normalize_text(value)
+    if text is None:
+        return None
+
+    compact = text.replace("-", " ").replace("/", " ")
+    compact = re.sub(r"\s+", " ", compact).strip()
+    enum = compact.replace(" ", "_")
+
+    aliases = {
+        "machine_wash_cold": "machine_wash_cold",
+        "machine_wash_warm": "machine_wash_warm",
+        "machine_wash_hot": "machine_wash_hot",
+        "machine_wash_gentle": "machine_wash_gentle",
+        "gentle_cycle": "machine_wash_gentle",
+        "hand_wash_cold": "hand_wash_cold",
+        "hand_wash_warm": "hand_wash_warm",
+        "tumble_dry_low": "tumble_dry_low",
+        "tumble_dry_medium": "tumble_dry_medium",
+        "tumble_dry_high": "tumble_dry_high",
+        "lay_flat_to_dry": "lay_flat_to_dry",
+        "dry_flat": "lay_flat_to_dry",
+        "line_dry": "line_dry",
+        "do_not_tumble_dry": "do_not_tumble_dry",
+        "iron_low": "iron_low",
+        "cool_iron": "iron_low",
+        "iron_medium": "iron_medium",
+        "warm_iron": "iron_medium",
+        "iron_high": "iron_high",
+        "do_not_iron": "do_not_iron",
+        "dry_clean": "dry_clean",
+        "professional_clean": "dry_clean",
+        "dry_clean_only": "dry_clean_only",
+    }
+    return aliases.get(enum, enum)
+
+
+def material_items(parsed: dict[str, Any]) -> list[dict[str, float | str | None]]:
+    raw_materials = parsed.get("materials")
+    if not isinstance(raw_materials, list):
+        return []
+
+    items = []
+    for item in raw_materials:
+        if not isinstance(item, dict):
+            continue
+        fiber = normalize_fiber(
+            item.get("fiber")
+            or item.get("material")
+            or item.get("name")
+        )
+        if fiber is None:
+            continue
+        pct = normalize_pct(
+            item.get("pct")
+            if "pct" in item
+            else item.get("percent", item.get("percentage"))
+        )
+        items.append({"fiber": fiber, "pct": pct})
+    return items
+
+
+def update_scalar(counts: Counts, truth: str | None, pred: str | None) -> None:
+    if truth is None and pred is None:
+        return
+    if truth is not None and pred is not None and truth == pred:
+        counts.tp += 1
+        return
+    if pred is not None:
+        counts.fp += 1
+    if truth is not None:
+        counts.fn += 1
+
+
+def materials_match(
+    truth: dict[str, float | str | None],
+    pred: dict[str, float | str | None],
+    pct_tolerance: float,
+) -> bool:
+    if truth["fiber"] != pred["fiber"]:
+        return False
+    truth_pct = truth["pct"]
+    pred_pct = pred["pct"]
+    if truth_pct is None or pred_pct is None:
+        return truth_pct is None and pred_pct is None
+    return abs(float(truth_pct) - float(pred_pct)) <= pct_tolerance
+
+
+def update_materials(
+    counts: Counts,
+    truth_items: list[dict[str, float | str | None]],
+    pred_items: list[dict[str, float | str | None]],
+    pct_tolerance: float,
+) -> None:
+    matched_pred_indexes: set[int] = set()
+
+    for truth in truth_items:
+        best_index = None
+        best_delta = math.inf
+        for idx, pred in enumerate(pred_items):
+            if idx in matched_pred_indexes:
+                continue
+            if not materials_match(truth, pred, pct_tolerance):
+                continue
+            truth_pct = truth["pct"]
+            pred_pct = pred["pct"]
+            delta = (
+                abs(float(truth_pct) - float(pred_pct))
+                if truth_pct is not None and pred_pct is not None
+                else 0
+            )
+            if delta < best_delta:
+                best_delta = delta
+                best_index = idx
+
+        if best_index is None:
+            counts.fn += 1
+        else:
+            counts.tp += 1
+            matched_pred_indexes.add(best_index)
+
+    counts.fp += len(pred_items) - len(matched_pred_indexes)
+
+
+def load_ground_truths(gt_root: Path, suffix: str) -> list[dict[str, Any]]:
+    gt_paths = sorted(gt_root.rglob(f"*{suffix}"))
+    if not gt_paths:
+        raise SystemExit(f"No ground truth files matching '*{suffix}' found in {gt_root}")
+
+    rows = []
+    for gt_path in gt_paths:
+        relative = gt_path.relative_to(gt_root)
+        relative_image = str(relative)[: -len(suffix)]
+        rows.append(
+            {
+                "image": Path(relative_image).name,
+                "relative_image": relative_image,
+                "path": gt_path,
+                "parsed": extract_parsed(load_json(gt_path)),
+            }
+        )
+    return rows
+
+
+def load_predictions_file(path: Path) -> dict[str, dict[str, Any]]:
+    payload = load_json(path)
+    predictions: dict[str, dict[str, Any]] = {}
+
+    def add_row(row: Any) -> None:
+        if not isinstance(row, dict):
+            return
+        file_value = row.get("file") or row.get("image") or row.get("source_image")
+        if file_value is None:
+            return
+        image_name = Path(str(file_value)).name
+        predictions[image_name] = extract_parsed(row)
+
+    if isinstance(payload, list):
+        for row in payload:
+            add_row(row)
+    elif isinstance(payload, dict):
+        if isinstance(payload.get("results"), list):
+            for row in payload["results"]:
+                add_row(row)
+        elif any(key in payload for key in ("file", "image", "source_image")):
+            add_row(payload)
+        else:
+            for key, value in payload.items():
+                if isinstance(value, dict):
+                    predictions[Path(str(key)).name] = extract_parsed(value)
+
+    if not predictions:
+        raise SystemExit(f"{path}: no predictions found")
+    return predictions
+
+
+def prediction_from_dir(
+    gt_root: Path,
+    pred_root: Path,
+    gt_path: Path,
+    gt_suffix: str,
+    pred_suffix: str,
+) -> tuple[dict[str, Any], Path | None]:
+    relative_gt = gt_path.relative_to(gt_root)
+    relative_prediction = Path(str(relative_gt)[: -len(gt_suffix)] + pred_suffix)
+    candidates = [
+        pred_root / relative_prediction,
+        pred_root / (Path(str(relative_prediction)).name),
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return extract_parsed(load_json(candidate)), candidate
+    return empty_parsed(), None
+
+
+def score_rows(
+    rows: list[dict[str, Any]],
+    predictions_by_image: dict[str, dict[str, Any]] | None,
+    pred_root: Path | None,
+    gt_root: Path,
+    gt_suffix: str,
+    pred_suffix: str,
+    pct_tolerance: float,
+) -> dict[str, Any]:
+    counts = {field: Counts() for field in SCORED_FIELDS}
+    scalar_pairs: dict[str, list[tuple[str | None, str | None]]] = {
+        "country": [],
+        **{f"care.{field}": [] for field in CARE_FIELDS},
+    }
+    missing_predictions: list[str] = []
+
+    for row in rows:
+        truth = row["parsed"]
+        if predictions_by_image is not None:
+            pred = predictions_by_image.get(row["image"], empty_parsed())
+            if row["image"] not in predictions_by_image:
+                missing_predictions.append(row["relative_image"])
+        else:
+            pred, pred_path = prediction_from_dir(
+                gt_root,
+                pred_root or Path("."),
+                row["path"],
+                gt_suffix,
+                pred_suffix,
+            )
+            if pred_path is None:
+                missing_predictions.append(row["relative_image"])
+
+        truth_country = normalize_country(truth.get("country"))
+        pred_country = normalize_country(pred.get("country"))
+        update_scalar(counts["country"], truth_country, pred_country)
+        scalar_pairs["country"].append((truth_country, pred_country))
+
+        update_materials(
+            counts["materials"],
+            material_items(truth),
+            material_items(pred),
+            pct_tolerance,
+        )
+
+        truth_care = truth.get("care") if isinstance(truth.get("care"), dict) else {}
+        pred_care = pred.get("care") if isinstance(pred.get("care"), dict) else {}
+        for field in CARE_FIELDS:
+            field_name = f"care.{field}"
+            truth_value = normalize_care(truth_care.get(field))
+            pred_value = normalize_care(pred_care.get(field))
+            update_scalar(counts[field_name], truth_value, pred_value)
+            scalar_pairs[field_name].append((truth_value, pred_value))
+
+    overall = Counts()
+    for field_counts in counts.values():
+        overall.add(field_counts)
+
+    return {
+        "image_count": len(rows),
+        "missing_predictions": missing_predictions,
+        "fields": {field: counts[field].as_dict() for field in SCORED_FIELDS},
+        "overall": overall.as_dict(),
+        "scalar_pairs": scalar_pairs,
+    }
+
+
+def sklearn_check(scalar_pairs: dict[str, list[tuple[str | None, str | None]]]) -> dict[str, Any]:
+    try:
+        from sklearn.metrics import precision_recall_fscore_support
+    except ImportError:
+        return {
+            "available": False,
+            "message": "scikit-learn is not installed; install it to use --check-sklearn.",
+        }
+
+    results: dict[str, Any] = {"available": True, "fields": {}}
+    for field, pairs in scalar_pairs.items():
+        labels = sorted(
+            {
+                value
+                for truth, pred in pairs
+                for value in (truth, pred)
+                if value is not None
+            }
+        )
+        if not labels:
+            continue
+        y_true = [truth if truth is not None else MISSING_LABEL for truth, _ in pairs]
+        y_pred = [pred if pred is not None else MISSING_LABEL for _, pred in pairs]
+        precision, recall, f1, _support = precision_recall_fscore_support(
+            y_true,
+            y_pred,
+            labels=labels,
+            average="micro",
+            zero_division=0,
+        )
+        results["fields"][field] = {
+            "precision": round(float(precision), 4),
+            "recall": round(float(recall), 4),
+            "f1": round(float(f1), 4),
+        }
+    return results
+
+
+def print_table(result: dict[str, Any]) -> None:
+    print(f"Scored images: {result['image_count']}")
+    print(f"Missing predictions: {len(result['missing_predictions'])}")
+    print()
+    print(f"{'field':<22} {'tp':>4} {'fp':>4} {'fn':>4} {'prec':>7} {'recall':>7} {'f1':>7}")
+    print("-" * 62)
+    for field in SCORED_FIELDS:
+        row = result["fields"][field]
+        print(
+            f"{field:<22} {row['tp']:>4} {row['fp']:>4} {row['fn']:>4} "
+            f"{row['precision']:>7.3f} {row['recall']:>7.3f} {row['f1']:>7.3f}"
+        )
+    row = result["overall"]
+    print("-" * 62)
+    print(
+        f"{'overall':<22} {row['tp']:>4} {row['fp']:>4} {row['fn']:>4} "
+        f"{row['precision']:>7.3f} {row['recall']:>7.3f} {row['f1']:>7.3f}"
+    )
+
+    if result["missing_predictions"]:
+        print()
+        print("Missing prediction files:")
+        for image in result["missing_predictions"]:
+            print(f"  {image}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare EcoTag system outputs with .json.gt ground truth files."
+    )
+    parser.add_argument("--ground-truth-dir", default="cropped_tags")
+    parser.add_argument("--ground-truth-suffix", default=".json.gt")
+
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--predictions-dir")
+    source.add_argument("--predictions-file")
+
+    parser.add_argument("--prediction-suffix", default=".json")
+    parser.add_argument(
+        "--pct-tolerance",
+        type=float,
+        default=0.0,
+        help="Allowed absolute percentage-point difference for material pct matches.",
+    )
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    parser.add_argument("--check-sklearn", action="store_true")
+    parser.add_argument("--fail-on-missing", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    gt_root = Path(args.ground_truth_dir)
+    rows = load_ground_truths(gt_root, args.ground_truth_suffix)
+
+    predictions_by_image = None
+    pred_root = None
+    if args.predictions_file:
+        predictions_by_image = load_predictions_file(Path(args.predictions_file))
+    else:
+        pred_root = Path(args.predictions_dir)
+
+    result = score_rows(
+        rows=rows,
+        predictions_by_image=predictions_by_image,
+        pred_root=pred_root,
+        gt_root=gt_root,
+        gt_suffix=args.ground_truth_suffix,
+        pred_suffix=args.prediction_suffix,
+        pct_tolerance=args.pct_tolerance,
+    )
+
+    if args.check_sklearn:
+        result["sklearn_check"] = sklearn_check(result["scalar_pairs"])
+
+    result.pop("scalar_pairs", None)
+
+    if args.json_output:
+        print(json.dumps(result, indent=2))
+    else:
+        print_table(result)
+        if args.check_sklearn:
+            print()
+            print("sklearn check:")
+            print(json.dumps(result["sklearn_check"], indent=2))
+
+    if args.fail_on_missing and result["missing_predictions"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/start-backend.sh
+++ b/scripts/start-backend.sh
@@ -5,7 +5,7 @@ BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../backend" && pwd)"
 
 if [ ! -f "$BACKEND_DIR/.env" ]; then
   echo "Error: $BACKEND_DIR/.env not found."
-  echo "Copy .env.example and fill in your OPENAI_API_KEY:"
+  echo "Copy .env.example and fill in the API key for your selected VLM_PROVIDER:"
   echo "  cp $BACKEND_DIR/.env.example $BACKEND_DIR/.env"
   exit 1
 fi

--- a/scripts/tag.py
+++ b/scripts/tag.py
@@ -102,16 +102,17 @@ def main():
             errors += 1
             continue
 
-        print(f"{path}", end=" ... ", flush=True)
+        progress_stream = sys.stderr if args.json_output else sys.stdout
+        print(f"{path}", end=" ... ", flush=True, file=progress_stream)
         try:
             data, headers = submit(path, args.url)
-            print("ok")
+            print("ok", file=progress_stream)
             if args.json_output:
                 results.append({"file": str(path), "result": data})
             else:
                 print(format_result(data, headers))
         except requests.HTTPError as e:
-            print(f"HTTP {e.response.status_code}")
+            print(f"HTTP {e.response.status_code}", file=progress_stream)
             try:
                 err = e.response.json()
                 print(f"  Error: {err['error']['code']}: {err['error']['message']}", file=sys.stderr)
@@ -119,11 +120,11 @@ def main():
                 print(f"  {e}", file=sys.stderr)
             errors += 1
         except requests.ConnectionError:
-            print("connection refused")
+            print("connection refused", file=progress_stream)
             print(f"  Is the backend running at {args.url}?", file=sys.stderr)
             errors += 1
         except Exception as e:
-            print(f"failed")
+            print(f"failed", file=progress_stream)
             print(f"  {e}", file=sys.stderr)
             errors += 1
 


### PR DESCRIPTION
## Summary
Adds a ground-truth evaluation workflow for tag predictions, plus supporting tweaks.

- **`scripts/score_ground_truth.py`** — compares `.json.gt` ground-truth files against system predictions and reports per-field precision / recall / F1. Supports batch prediction files, per-image prediction dirs, and a self-check mode.
- **`cropped_tags/*.JPG.json.gt`** — hand-labeled ground truth for a sample of crops.
- **`docs/evaluation.md`**, **`docs/ground-truth-label-notes.md`** — the evaluation workflow and per-image labeling notes (including tricky edge cases).
- **`scripts/README.md`** — documents the scorer.
- **`scripts/tag.py`** — routes progress output to stderr in `--json` mode so JSON stdout stays clean (pipeable into the scorer).
- **`scripts/start-backend.sh`** — generalizes the missing-key error message to reference the selected `VLM_PROVIDER` instead of hardcoding `OPENAI_API_KEY`.
- **`.gitignore`** — ignores the local `read.txt` working file.

## Test plan
- `python scripts/score_ground_truth.py --ground-truth-dir cropped_tags --predictions-dir cropped_tags --prediction-suffix .json.gt` self-check.
- `python scripts/tag.py <img> --json-output | <scorer>` to confirm clean JSON on stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)